### PR TITLE
Fixed a bug in resolving the Windows slack directory for minor versions greater than 4.9.x

### DIFF
--- a/lib/consts.js
+++ b/lib/consts.js
@@ -8,8 +8,10 @@ const LINUX_DIR = `/usr/lib/slack/resources`;
 const PATH = `/app.asar.unpacked/dist/`;
 
 function getWindowsDirectory() {
-  for (let i = 9; i >= 0; --i) {
-    for (let j = 9; j >= 0; --j) {
+  const minorVersionMax = 99;
+  const patchVersionMax = 99;
+  for (let i = minorVersionMax; i >= 0; --i) {
+    for (let j = patchVersionMax; j >= 0; --j) {
       const ver = `4.${i}.${j}`;
 
       const dir = `${homeDir}\\AppData\\Local\\slack\\app-${ver}\\resources`;


### PR DESCRIPTION
I think ideally there is a better way to resolve the directory - either through regex or some other mechanism.  This will fix the issue for now and get people on Windows working again.