### PR TITLE
Fixes case sensitive filename issue on Linux

### DIFF
--- a/main.js
+++ b/main.js
@@ -10,7 +10,7 @@ const pkg = require('./package.json');
 
 async function run() {
   console.log(chalk.yellow(figlet.textSync('mtslack', {
-    font: sample(['whimsy']),
+    font: sample(['Whimsy']),
     horizontalLayout: 'default',
     verticalLayout: 'default',
     width: 80,


### PR DESCRIPTION
Fixes https://github.com/mallowigi/mtslack/issues/53

Linux is case sensitive for filename, and the right name for the font is [Whimsy.flf](https://github.com/patorjk/figlet.js/blob/master/fonts/Whimsy.flf).

This change should work well with Mac and Windows, although I didn't test it on them.