### PR TITLE
Use clipboardy for cross platform copy-paste

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -219,12 +219,12 @@ exports.apply = async (archive) => {
   bottomBar.updateBottomBar(chalk.green('🌟 Slack successfully tweaked. 🌟 Please restart Slack.'));
 };
 
-exports.copyToClipboard = () => {
+exports.copyToClipboard = async () => {
   // Apply theme first
   themes.changeTheme('oceanic');
 
   // copy to clipboard
-  copyToClipboard(generateJS());
+  await copyToClipboard(generateJS());
 
   bottomBar.updateBottomBar(
     chalk.green('🌟 Code copied to clipboard. 🌟 Please paste the code to your Slack Dev Tools console.')
@@ -345,7 +345,6 @@ exports.execute = async (answer) => {
         break;
       case 'exit':
         process.exit(0);
-        break;
       default:
         console.error(chalk.red('Unknown command:', answer));
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,24 +1,3 @@
-const os = require('os');
-exports.pbcopy = (data) => {
-  const proc = require('child_process').spawn('pbcopy');
-  proc.stdin.write(data);
-  proc.stdin.end();
-};
-
-exports.windowsCopy = (data) => {
-  require('child_process').spawn('clip').stdin.end(data);
-};
-
-exports.copyToClipboard = (data) => {
-  const osType = os.type();
-  switch (osType) {
-    case 'Linux':
-      return this.pbcopy(data);
-    case 'Windows_NT':
-      return this.windowsCopy(data);
-    case 'Darwin':
-      return this.pbcopy(data);
-    default:
-      throw 'Unsupported operating system';
-  }
-};
+// Unfortunately we have to import like this
+// because clipboardy is ESM and we're in CJS
+exports.copyToClipboard = (text) => import('clipboardy').then((module) => module.default.write(text));

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "chalk": "^4.1.2",
         "clear": "^0.1.0",
         "cli-autoupdate": "^2.0.4",
+        "clipboardy": "^3.0.0",
         "clui": "^0.3.6",
         "configstore": "^6.0.0",
         "figlet": "^1.5.2",
@@ -772,6 +773,25 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/arch": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
+      "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/archy": {
       "version": "1.0.0",
@@ -1792,6 +1812,22 @@
       "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/clipboardy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-3.0.0.tgz",
+      "integrity": "sha512-Su+uU5sr1jkUy1sGRpLKjKrvEOVXgSgiSInwa/qeID6aJ07yh+5NWc3h2QfjHjBnfX4LhtFcuAWKUsJ3r+fjbg==",
+      "dependencies": {
+        "arch": "^2.2.0",
+        "execa": "^5.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cliui": {
@@ -5421,6 +5457,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-elevated": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-elevated/-/is-elevated-4.0.0.tgz",
@@ -5738,6 +5788,17 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/isarray": {
@@ -6977,6 +7038,8 @@
     },
     "node_modules/npx/node_modules/ansi-align": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
+      "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -6986,6 +7049,8 @@
     },
     "node_modules/npx/node_modules/ansi-regex": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6995,6 +7060,8 @@
     },
     "node_modules/npx/node_modules/ansi-styles": {
       "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7007,12 +7074,16 @@
     },
     "node_modules/npx/node_modules/balanced-match": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/boxen": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
+      "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7031,6 +7102,8 @@
     },
     "node_modules/npx/node_modules/brace-expansion": {
       "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7041,12 +7114,16 @@
     },
     "node_modules/npx/node_modules/builtins": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
+      "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/camelcase": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7056,6 +7133,8 @@
     },
     "node_modules/npx/node_modules/capture-stack-trace": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
+      "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7065,6 +7144,8 @@
     },
     "node_modules/npx/node_modules/chalk": {
       "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7079,12 +7160,16 @@
     },
     "node_modules/npx/node_modules/ci-info": {
       "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
+      "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/cli-boxes": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7094,6 +7179,8 @@
     },
     "node_modules/npx/node_modules/cliui": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+      "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -7105,6 +7192,8 @@
     },
     "node_modules/npx/node_modules/code-point-at": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7114,6 +7203,8 @@
     },
     "node_modules/npx/node_modules/color-convert": {
       "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7123,18 +7214,24 @@
     },
     "node_modules/npx/node_modules/color-name": {
       "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/concat-map": {
       "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/configstore": {
       "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
+      "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -7152,6 +7249,8 @@
     },
     "node_modules/npx/node_modules/create-error-class": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7164,6 +7263,8 @@
     },
     "node_modules/npx/node_modules/cross-spawn": {
       "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7175,6 +7276,8 @@
     },
     "node_modules/npx/node_modules/crypto-random-string": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7184,6 +7287,8 @@
     },
     "node_modules/npx/node_modules/decamelize": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7193,6 +7298,8 @@
     },
     "node_modules/npx/node_modules/deep-extend": {
       "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7202,6 +7309,8 @@
     },
     "node_modules/npx/node_modules/dot-prop": {
       "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+      "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7214,6 +7323,8 @@
     },
     "node_modules/npx/node_modules/dotenv": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
+      "integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -7223,12 +7334,16 @@
     },
     "node_modules/npx/node_modules/duplexer3": {
       "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/npx/node_modules/end-of-stream": {
       "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7238,6 +7353,8 @@
     },
     "node_modules/npx/node_modules/escape-string-regexp": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7247,6 +7364,8 @@
     },
     "node_modules/npx/node_modules/execa": {
       "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7265,6 +7384,8 @@
     },
     "node_modules/npx/node_modules/find-up": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7277,18 +7398,24 @@
     },
     "node_modules/npx/node_modules/fs.realpath": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npx/node_modules/get-caller-file": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npx/node_modules/get-stream": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7298,6 +7425,8 @@
     },
     "node_modules/npx/node_modules/glob": {
       "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -7318,6 +7447,8 @@
     },
     "node_modules/npx/node_modules/global-dirs": {
       "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+      "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7330,6 +7461,8 @@
     },
     "node_modules/npx/node_modules/got": {
       "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+      "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7352,12 +7485,16 @@
     },
     "node_modules/npx/node_modules/graceful-fs": {
       "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npx/node_modules/has-flag": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7367,12 +7504,16 @@
     },
     "node_modules/npx/node_modules/hosted-git-info": {
       "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
+      "integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npx/node_modules/import-lazy": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+      "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7382,6 +7523,8 @@
     },
     "node_modules/npx/node_modules/imurmurhash": {
       "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7391,6 +7534,8 @@
     },
     "node_modules/npx/node_modules/inflight": {
       "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -7401,12 +7546,16 @@
     },
     "node_modules/npx/node_modules/inherits": {
       "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npx/node_modules/ini": {
       "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -7416,6 +7565,8 @@
     },
     "node_modules/npx/node_modules/invert-kv": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+      "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7425,6 +7576,8 @@
     },
     "node_modules/npx/node_modules/is-ci": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
+      "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7437,6 +7590,8 @@
     },
     "node_modules/npx/node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7446,6 +7601,8 @@
     },
     "node_modules/npx/node_modules/is-installed-globally": {
       "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+      "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7459,6 +7616,8 @@
     },
     "node_modules/npx/node_modules/is-npm": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+      "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7468,6 +7627,8 @@
     },
     "node_modules/npx/node_modules/is-obj": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7477,6 +7638,8 @@
     },
     "node_modules/npx/node_modules/is-path-inside": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7489,6 +7652,8 @@
     },
     "node_modules/npx/node_modules/is-redirect": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7498,6 +7663,8 @@
     },
     "node_modules/npx/node_modules/is-retry-allowed": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7507,6 +7674,8 @@
     },
     "node_modules/npx/node_modules/is-stream": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7516,12 +7685,16 @@
     },
     "node_modules/npx/node_modules/isexe": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npx/node_modules/latest-version": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
+      "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7534,6 +7707,8 @@
     },
     "node_modules/npx/node_modules/lcid": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+      "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7546,6 +7721,8 @@
     },
     "node_modules/npx/node_modules/libnpx": {
       "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/libnpx/-/libnpx-10.2.2.tgz",
+      "integrity": "sha512-ujaYToga1SAX5r7FU5ShMFi88CWpY75meNZtr6RtEyv4l2ZK3+Wgvxq2IqlwWBiDZOqhumdeiocPS1aKrCMe3A==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -7565,6 +7742,8 @@
     },
     "node_modules/npx/node_modules/locate-path": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7578,6 +7757,8 @@
     },
     "node_modules/npx/node_modules/lowercase-keys": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7587,6 +7768,8 @@
     },
     "node_modules/npx/node_modules/lru-cache": {
       "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -7597,6 +7780,8 @@
     },
     "node_modules/npx/node_modules/make-dir": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+      "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7609,6 +7794,8 @@
     },
     "node_modules/npx/node_modules/map-age-cleaner": {
       "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7621,6 +7808,8 @@
     },
     "node_modules/npx/node_modules/mem": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+      "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7635,6 +7824,8 @@
     },
     "node_modules/npx/node_modules/mimic-fn": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7644,6 +7835,8 @@
     },
     "node_modules/npx/node_modules/minimatch": {
       "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -7656,18 +7849,24 @@
     },
     "node_modules/npx/node_modules/minimist": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/nice-try": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm": {
       "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-5.1.0.tgz",
+      "integrity": "sha512-pt5ClxEmY/dLpb60SmGQQBKi3nB6Ljx1FXmpoCUdAULlGqGVn2uCyXxPCWFbcuHGthT7qGiaGa1wOfs/UjGYMw==",
       "bundleDependencies": [
         "abbrev",
         "ansi-regex",
@@ -7873,6 +8072,8 @@
     },
     "node_modules/npx/node_modules/npm-package-arg": {
       "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.1.1.tgz",
+      "integrity": "sha512-qBpssaL3IOZWi5vEKUKW0cO7kzLeT+EQO9W8RsLOZf76KF9E/K9+wH0C7t06HXPpaH8WH5xF1MExLuCwbTqRUg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -7885,6 +8086,8 @@
     },
     "node_modules/npx/node_modules/npm-run-path": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7897,12 +8100,16 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/abbrev": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+      "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npx/node_modules/npm/node_modules/ansi-regex": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7912,36 +8119,48 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/ansicolors": {
       "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
+      "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/ansistyles": {
       "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
+      "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/aproba": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz",
+      "integrity": "sha512-ZpYajIfO0j2cOFTO955KUMIKNmj6zhX8kVztMAxFsDaMwz+9Z9SV0uou2pC9HJqcfpffOsjnbrDMvkNy+9RXPw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npx/node_modules/npm/node_modules/archy": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/bluebird": {
       "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+      "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/cacache": {
       "version": "9.2.9",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-9.2.9.tgz",
+      "integrity": "sha512-ghg1j5OyTJ6qsrqU++dN23QiTDxb5AZCFGsF3oB+v9v/gY+F4X8L/0gdQMEjd+8Ot3D29M2etX5PKozHRn2JQw==",
       "dev": true,
       "inBundle": true,
       "license": "CC0-1.0",
@@ -7963,6 +8182,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/cacache/node_modules/lru-cache": {
       "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -7973,36 +8194,48 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/cacache/node_modules/lru-cache/node_modules/pseudomap": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npx/node_modules/npm/node_modules/cacache/node_modules/lru-cache/node_modules/yallist": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npx/node_modules/npm/node_modules/cacache/node_modules/y18n": {
       "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npx/node_modules/npm/node_modules/call-limit": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/call-limit/-/call-limit-1.1.0.tgz",
+      "integrity": "sha1-b9YbA/PaQqLNDsK2DwK9DnGZH+o=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npx/node_modules/npm/node_modules/chownr": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+      "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npx/node_modules/npm/node_modules/cmd-shim": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
+      "integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -8013,6 +8246,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/columnify": {
       "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
+      "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8023,6 +8258,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/columnify/node_modules/strip-ansi": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8035,6 +8272,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/columnify/node_modules/strip-ansi/node_modules/ansi-regex": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8044,6 +8283,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/columnify/node_modules/wcwidth": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8053,6 +8294,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/columnify/node_modules/wcwidth/node_modules/defaults": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8062,6 +8305,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/columnify/node_modules/wcwidth/node_modules/defaults/node_modules/clone": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+      "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8071,6 +8316,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/config-chain": {
       "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
+      "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
       "dev": true,
       "inBundle": true,
       "dependencies": {
@@ -8080,12 +8327,16 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/config-chain/node_modules/proto-list": {
       "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npx/node_modules/npm/node_modules/debuglog": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+      "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8095,6 +8346,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/detect-indent": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
+      "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8104,6 +8357,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/dezalgo": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
+      "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8114,18 +8369,24 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/dezalgo/node_modules/asap": {
       "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz",
+      "integrity": "sha1-UidltQw1EEkOUtfc/ghe+bqWlY8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/editor": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz",
+      "integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/fs-vacuum": {
       "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/fs-vacuum/-/fs-vacuum-1.2.10.tgz",
+      "integrity": "sha1-t2Kb7AekAxolSP35n17PHMizHjY=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8137,6 +8398,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/fs-write-stream-atomic": {
       "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+      "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8149,6 +8412,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/fstream": {
       "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8164,6 +8429,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/fstream-npm": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/fstream-npm/-/fstream-npm-1.2.1.tgz",
+      "integrity": "sha512-iBHpm/LmD1qw0TlHMAqVd9rwdU6M+EHRUnPkXpRi5G/Hf0FIFH+oZFryodAU2MFNfGRh/CzhUFlMKV3pdeOTDw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8174,6 +8441,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/fstream-npm/node_modules/fstream-ignore": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+      "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8185,6 +8454,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/fstream-npm/node_modules/fstream-ignore/node_modules/minimatch": {
       "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8197,6 +8468,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/fstream-npm/node_modules/fstream-ignore/node_modules/minimatch/node_modules/brace-expansion": {
       "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8207,18 +8480,24 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/fstream-npm/node_modules/fstream-ignore/node_modules/minimatch/node_modules/brace-expansion/node_modules/balanced-match": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/fstream-npm/node_modules/fstream-ignore/node_modules/minimatch/node_modules/brace-expansion/node_modules/concat-map": {
       "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/glob": {
       "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8236,12 +8515,16 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/glob/node_modules/fs.realpath": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npx/node_modules/npm/node_modules/glob/node_modules/minimatch": {
       "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8254,6 +8537,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/glob/node_modules/minimatch/node_modules/brace-expansion": {
       "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8264,18 +8549,24 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/glob/node_modules/minimatch/node_modules/brace-expansion/node_modules/balanced-match": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/glob/node_modules/minimatch/node_modules/brace-expansion/node_modules/concat-map": {
       "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/glob/node_modules/path-is-absolute": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8285,6 +8576,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/graceful-fs": {
       "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8294,24 +8587,32 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/has-unicode": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npx/node_modules/npm/node_modules/hosted-git-info": {
       "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npx/node_modules/npm/node_modules/iferr": {
       "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+      "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/imurmurhash": {
       "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8321,6 +8622,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/inflight": {
       "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8331,12 +8634,16 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/inherits": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npx/node_modules/npm/node_modules/ini": {
       "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+      "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8346,6 +8653,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/init-package-json": {
       "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.10.1.tgz",
+      "integrity": "sha1-zYc6FneWvvuZYSsodioLY5P9j2o=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8362,6 +8671,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/init-package-json/node_modules/promzard": {
       "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
+      "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8371,6 +8682,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/JSONStream": {
       "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
       "dev": true,
       "inBundle": true,
       "license": "(MIT OR Apache-2.0)",
@@ -8387,6 +8700,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/JSONStream/node_modules/jsonparse": {
       "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true,
       "engines": [
         "node >= 0.2.0"
@@ -8396,30 +8711,40 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/JSONStream/node_modules/through": {
       "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/lazy-property": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lazy-property/-/lazy-property-1.0.0.tgz",
+      "integrity": "sha1-hN3Es3Bnm6i9TNz6TAa0PVcREUc=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/lockfile": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.3.tgz",
+      "integrity": "sha1-Jjj8OaAzHpysGgS3F5mTHJxQ33k=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npx/node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
+      "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/lodash._baseuniq": {
       "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz",
+      "integrity": "sha1-DrtE5FaBSveQXGIS+iybLVG4Qeg=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8430,30 +8755,40 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/lodash._baseuniq/node_modules/lodash._createset": {
       "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._createset/-/lodash._createset-4.0.3.tgz",
+      "integrity": "sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/lodash._baseuniq/node_modules/lodash._root": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+      "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
+      "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
+      "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8463,42 +8798,56 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/lodash.clonedeep": {
       "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/lodash.union": {
       "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+      "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/lodash.uniq": {
       "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/lodash.without": {
       "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz",
+      "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/lru-cache": {
       "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8509,18 +8858,24 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/lru-cache/node_modules/pseudomap": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npx/node_modules/npm/node_modules/lru-cache/node_modules/yallist": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npx/node_modules/npm/node_modules/mississippi": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-1.3.0.tgz",
+      "integrity": "sha1-0gFYPrEjJ+PFwWQqQEqcrPlONPU=",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -8539,6 +8894,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/mississippi/node_modules/concat-stream": {
       "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
       "dev": true,
       "engines": [
         "node >= 0.8"
@@ -8553,12 +8910,16 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/mississippi/node_modules/concat-stream/node_modules/typedarray": {
       "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/mississippi/node_modules/duplexify": {
       "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz",
+      "integrity": "sha1-GqdzAC4VeEV+nZ1KULDMquvL1gQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8571,6 +8932,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/mississippi/node_modules/duplexify/node_modules/end-of-stream": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+      "integrity": "sha1-1FlucCc0qT5A6a+GQxnqvZn/Lw4=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8580,6 +8943,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/mississippi/node_modules/duplexify/node_modules/end-of-stream/node_modules/once": {
       "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+      "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8589,12 +8954,16 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/mississippi/node_modules/duplexify/node_modules/stream-shift": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/mississippi/node_modules/end-of-stream": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
+      "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8604,6 +8973,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/mississippi/node_modules/flush-write-stream": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.2.tgz",
+      "integrity": "sha1-yBuQ2HRnZvGmCaRoCZRsRd2K5Bc=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8614,6 +8985,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/mississippi/node_modules/from2": {
       "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8624,6 +8997,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/mississippi/node_modules/parallel-transform": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
+      "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8635,11 +9010,15 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/mississippi/node_modules/parallel-transform/node_modules/cyclist": {
       "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
+      "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
       "dev": true,
       "inBundle": true
     },
     "node_modules/npx/node_modules/npm/node_modules/mississippi/node_modules/pump": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz",
+      "integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8650,6 +9029,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/mississippi/node_modules/pumpify": {
       "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.5.tgz",
+      "integrity": "sha1-G2ccYZlAq8rqwK0OOjwWS+dgmTs=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8661,6 +9042,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/mississippi/node_modules/stream-each": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.0.tgz",
+      "integrity": "sha1-HpXUdXP1gNgU3A/4zQ9m8c5TyZE=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8671,12 +9054,16 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/mississippi/node_modules/stream-each/node_modules/stream-shift": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/mississippi/node_modules/through2": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8687,6 +9074,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/mississippi/node_modules/through2/node_modules/xtend": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8696,6 +9085,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/mkdirp": {
       "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8708,12 +9099,16 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/mkdirp/node_modules/minimist": {
       "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/move-concurrently": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
+      "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8728,6 +9123,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/move-concurrently/node_modules/copy-concurrently": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.3.tgz",
+      "integrity": "sha1-Rft4ZiSaHKiJqlcI5svSc+dbslA=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8742,6 +9139,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/move-concurrently/node_modules/run-queue": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
+      "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8751,6 +9150,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/node-gyp": {
       "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
+      "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8778,6 +9179,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/node-gyp/node_modules/minimatch": {
       "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8790,6 +9193,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/node-gyp/node_modules/minimatch/node_modules/brace-expansion": {
       "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8800,18 +9205,24 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/node-gyp/node_modules/minimatch/node_modules/brace-expansion/node_modules/balanced-match": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/node-gyp/node_modules/minimatch/node_modules/brace-expansion/node_modules/concat-map": {
       "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/node-gyp/node_modules/nopt": {
       "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8824,6 +9235,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/nopt": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+      "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8837,6 +9250,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/normalize-package-data": {
       "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -8849,6 +9264,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/normalize-package-data/node_modules/is-builtin-module": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8861,6 +9278,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/normalize-package-data/node_modules/is-builtin-module/node_modules/builtin-modules": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8870,12 +9289,16 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/npm-cache-filename": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz",
+      "integrity": "sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npx/node_modules/npm/node_modules/npm-install-checks": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-3.0.0.tgz",
+      "integrity": "sha1-1K7N/VGlPjcjt7L5Oy7ijjB7wNc=",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -8885,6 +9308,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/npm-package-arg": {
       "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-5.1.2.tgz",
+      "integrity": "sha512-wJBsrf0qpypPT7A0LART18hCdyhpCMxeTtcb0X4IZO2jsP6Om7EHN1d9KSKiqD+KVH030RVNpWS9thk+pb7wzA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8897,6 +9322,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/npm-registry-client": {
       "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-8.4.0.tgz",
+      "integrity": "sha512-PVNfqq0lyRdFnE//nDmn3CC9uqTsr8Bya9KPLIevlXMfkP0m4RpCVyFFk0W1Gfx436kKwyhLA6J+lV+rgR81gQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8918,6 +9345,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/npm-registry-client/node_modules/concat-stream": {
       "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
       "dev": true,
       "engines": [
         "node >= 0.8"
@@ -8932,18 +9361,24 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/npm-registry-client/node_modules/concat-stream/node_modules/typedarray": {
       "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/npm-user-validate": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-1.0.0.tgz",
+      "integrity": "sha1-jOyg9c6gTU6TUZ73LQVXp1Ei6VE=",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/npx/node_modules/npm/node_modules/npmlog": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8956,6 +9391,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/npmlog/node_modules/are-we-there-yet": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+      "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8966,18 +9403,24 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/npmlog/node_modules/are-we-there-yet/node_modules/delegates": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/npmlog/node_modules/console-control-strings": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npx/node_modules/npm/node_modules/npmlog/node_modules/gauge": {
       "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8994,6 +9437,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/npmlog/node_modules/gauge/node_modules/object-assign": {
       "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9003,12 +9448,16 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/npmlog/node_modules/gauge/node_modules/signal-exit": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npx/node_modules/npm/node_modules/npmlog/node_modules/gauge/node_modules/string-width": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9023,6 +9472,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/npmlog/node_modules/gauge/node_modules/string-width/node_modules/code-point-at": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9032,6 +9483,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/npmlog/node_modules/gauge/node_modules/string-width/node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9044,6 +9497,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/npmlog/node_modules/gauge/node_modules/string-width/node_modules/is-fullwidth-code-point/node_modules/number-is-nan": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9053,6 +9508,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/npmlog/node_modules/gauge/node_modules/strip-ansi": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9065,6 +9522,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/npmlog/node_modules/gauge/node_modules/strip-ansi/node_modules/ansi-regex": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9074,6 +9533,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/npmlog/node_modules/gauge/node_modules/wide-align": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9083,12 +9544,16 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/npmlog/node_modules/set-blocking": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npx/node_modules/npm/node_modules/once": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9098,6 +9563,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/opener": {
       "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.3.tgz",
+      "integrity": "sha1-XG2ixdflgx6P+jlklQ+NZnSskLg=",
       "dev": true,
       "inBundle": true,
       "license": "(WTFPL OR MIT)",
@@ -9107,6 +9574,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/osenv": {
       "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+      "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9117,6 +9586,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/osenv/node_modules/os-homedir": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9126,6 +9597,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/osenv/node_modules/os-tmpdir": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9135,6 +9608,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/pacote": {
       "version": "2.7.38",
+      "resolved": "https://registry.npmjs.org/pacote/-/pacote-2.7.38.tgz",
+      "integrity": "sha512-XxHUyHQB7QCVBxoXeVu0yKxT+2PvJucsc0+1E+6f95lMUxEAYERgSAc71ckYXrYr35Ew3xFU/LrhdIK21GQFFA==",
       "dev": true,
       "inBundle": true,
       "license": "CC0-1.0",
@@ -9164,6 +9639,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen": {
       "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-2.4.13.tgz",
+      "integrity": "sha512-73CsTlMRSLdGr7VvOE8iYl/ejOSIxyfRYg7jZhepGGEqIlgdq6FLe2DEAI5bo813Jdg5fS/Ku62SRQ/UpT6NJA==",
       "dev": true,
       "inBundle": true,
       "license": "CC0-1.0",
@@ -9183,6 +9660,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/agentkeepalive": {
       "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.3.0.tgz",
+      "integrity": "sha512-9yhcpXti2ZQE7bxuCsjjWNIZoQOd9sZ1ZBovHG0YeCRohFv73SLvcm73PC9T3olM4GyozaQb+4MGdQpcD8m7NQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9195,6 +9674,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/agentkeepalive/node_modules/humanize-ms": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9204,18 +9685,24 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/agentkeepalive/node_modules/humanize-ms/node_modules/ms": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/http-cache-semantics": {
       "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.7.3.tgz",
+      "integrity": "sha1-LzXFMuzSnx5UE7mvgztySjxvf3I=",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/http-proxy-agent": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.0.0.tgz",
+      "integrity": "sha1-RkgqLwUjpNYIJVFwn0acs+SoX/Q=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9226,6 +9713,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/http-proxy-agent/node_modules/agent-base": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.1.0.tgz",
+      "integrity": "sha1-IOF0Ac1Js8B2v1akvGxbQ2/6jVU=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9238,6 +9727,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/http-proxy-agent/node_modules/agent-base/node_modules/es6-promisify": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9247,12 +9738,16 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/http-proxy-agent/node_modules/agent-base/node_modules/es6-promisify/node_modules/es6-promise": {
       "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
+      "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/http-proxy-agent/node_modules/debug": {
       "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9262,12 +9757,16 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/http-proxy-agent/node_modules/debug/node_modules/ms": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/https-proxy-agent": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.0.0.tgz",
+      "integrity": "sha1-/6pLb69YasNAwYoUBDHna31/KUQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9278,6 +9777,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/https-proxy-agent/node_modules/agent-base": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.1.0.tgz",
+      "integrity": "sha1-IOF0Ac1Js8B2v1akvGxbQ2/6jVU=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9290,6 +9791,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/https-proxy-agent/node_modules/agent-base/node_modules/es6-promisify": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9299,12 +9802,16 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/https-proxy-agent/node_modules/agent-base/node_modules/es6-promisify/node_modules/es6-promise": {
       "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
+      "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/https-proxy-agent/node_modules/debug": {
       "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9314,12 +9821,16 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/https-proxy-agent/node_modules/debug/node_modules/ms": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/node-fetch-npm": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.1.tgz",
+      "integrity": "sha512-W3onhopST5tqpX0/MGSL47pDQLLKobNR83AvkiOWQKaw54h+uYUfzeLAxCiyhWlUOiuI+GIb4O9ojLaAFlhCCA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9334,6 +9845,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/node-fetch-npm/node_modules/encoding": {
       "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9343,6 +9856,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/node-fetch-npm/node_modules/encoding/node_modules/iconv-lite": {
       "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
+      "integrity": "sha512-sr1ZQph3UwHTR0XftSbK85OvBbxe/abLGzEnPENCQwmHf7sck8Oyu4ob3LgBxWWxRoM+QszeUyl7jbqapu2TqA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9352,6 +9867,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/node-fetch-npm/node_modules/json-parse-helpfulerror": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
+      "integrity": "sha1-E/FM4C7tTpgSl7ZOueO5MuLdE9w=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9361,12 +9878,16 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/node-fetch-npm/node_modules/json-parse-helpfulerror/node_modules/jju": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/jju/-/jju-1.3.0.tgz",
+      "integrity": "sha1-2t2e8BkkvHKLA/L3l5vb1i96Kqo=",
       "dev": true,
       "inBundle": true,
       "license": "WTFPL"
     },
     "node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/socks-proxy-agent": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-3.0.0.tgz",
+      "integrity": "sha512-YJcT+SNNBgFoK/NpO20PChz0VnBOhkjG3X10BwlrYujd0NZlSsH1jbxSQ1S0njt3sOvzwQ2PvGqqUIvP4rNk/w==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9377,6 +9898,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/socks-proxy-agent/node_modules/agent-base": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.1.0.tgz",
+      "integrity": "sha1-IOF0Ac1Js8B2v1akvGxbQ2/6jVU=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9389,6 +9912,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/socks-proxy-agent/node_modules/agent-base/node_modules/es6-promisify": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9398,12 +9923,16 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/socks-proxy-agent/node_modules/agent-base/node_modules/es6-promisify/node_modules/es6-promise": {
       "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
+      "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/socks-proxy-agent/node_modules/socks": {
       "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-1.1.10.tgz",
+      "integrity": "sha1-W4t/x8jzQcU+0FbpKbe/Tei6e1o=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9418,12 +9947,16 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/socks-proxy-agent/node_modules/socks/node_modules/ip": {
       "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/make-fetch-happen/node_modules/socks-proxy-agent/node_modules/socks/node_modules/smart-buffer": {
       "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-1.1.15.tgz",
+      "integrity": "sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9434,6 +9967,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/minimatch": {
       "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9446,6 +9981,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/minimatch/node_modules/brace-expansion": {
       "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9456,18 +9993,24 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/minimatch/node_modules/brace-expansion/node_modules/balanced-match": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/minimatch/node_modules/brace-expansion/node_modules/concat-map": {
       "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/npm-pick-manifest": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-1.0.4.tgz",
+      "integrity": "sha512-MKxNdeyOZysPRTTbHtW0M5Fw38Jo/3ARsoGw5qjCfS+XGjvNB/Gb4qtAZUFmKPM2mVum+eX559eHvKywU856BQ==",
       "dev": true,
       "inBundle": true,
       "license": "CC0-1.0",
@@ -9478,6 +10021,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/promise-retry": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
+      "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9491,12 +10036,16 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/promise-retry/node_modules/err-code": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
+      "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/protoduck": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/protoduck/-/protoduck-4.0.0.tgz",
+      "integrity": "sha1-/kh02MeRM2bP2erRJFOiLNNlf44=",
       "dev": true,
       "inBundle": true,
       "license": "CC0-1.0",
@@ -9506,12 +10055,16 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/protoduck/node_modules/genfun": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/genfun/-/genfun-4.0.1.tgz",
+      "integrity": "sha1-7RAEHy5KfxsKOEZtF6XD4n3x38E=",
       "dev": true,
       "inBundle": true,
       "license": "CC0-1.0"
     },
     "node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/tar-fs": {
       "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.15.3.tgz",
+      "integrity": "sha1-7M+TXpQUk9gVECjmNuUc5MPKfyA=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9524,6 +10077,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/tar-fs/node_modules/pump": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz",
+      "integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9534,6 +10089,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/tar-fs/node_modules/pump/node_modules/end-of-stream": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
+      "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9543,6 +10100,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/tar-stream": {
       "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz",
+      "integrity": "sha1-NlSc8E7RrumyowwBQyUiONr5QBY=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9558,6 +10117,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/tar-stream/node_modules/bl": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
+      "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9567,6 +10128,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/tar-stream/node_modules/end-of-stream": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
+      "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9576,6 +10139,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/pacote/node_modules/tar-stream/node_modules/xtend": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9585,18 +10150,24 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/path-is-inside": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true,
       "inBundle": true,
       "license": "(WTFPL OR MIT)"
     },
     "node_modules/npx/node_modules/npm/node_modules/promise-inflight": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+      "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npx/node_modules/npm/node_modules/read": {
       "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+      "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9609,6 +10180,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/read-cmd-shim": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz",
+      "integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9618,6 +10191,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/read-installed": {
       "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
+      "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9635,12 +10210,16 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/read-installed/node_modules/util-extend": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz",
+      "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/read-package-json": {
       "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.9.tgz",
+      "integrity": "sha512-vuV8p921IgyelL4UOKv3FsRuRZSaRn30HanLAOKargsr8TbBEq+I3MgloSRXYuKhNdYP1wlEGilMWAIayA2RFg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9655,6 +10234,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/read-package-json/node_modules/json-parse-helpfulerror": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
+      "integrity": "sha1-E/FM4C7tTpgSl7ZOueO5MuLdE9w=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9664,12 +10245,16 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/read-package-json/node_modules/json-parse-helpfulerror/node_modules/jju": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/jju/-/jju-1.3.0.tgz",
+      "integrity": "sha1-2t2e8BkkvHKLA/L3l5vb1i96Kqo=",
       "dev": true,
       "inBundle": true,
       "license": "WTFPL"
     },
     "node_modules/npx/node_modules/npm/node_modules/read-package-tree": {
       "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.1.6.tgz",
+      "integrity": "sha512-FCX1aT3GWyY658wzDICef4p+n0dB+ENRct8E/Qyvppj6xVpOYerBHfUu7OP5Rt1/393Tdglguf5ju5DEX4wZNg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9683,12 +10268,16 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/read/node_modules/mute-stream": {
       "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npx/node_modules/npm/node_modules/readable-stream": {
       "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.2.tgz",
+      "integrity": "sha1-WgTfBeT1f+Pw3Gj90R3FyXx+b00=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9704,24 +10293,32 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/readable-stream/node_modules/core-util-is": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/readable-stream/node_modules/isarray": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/readable-stream/node_modules/process-nextick-args": {
       "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/readable-stream/node_modules/string_decoder": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9731,12 +10328,16 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/readable-stream/node_modules/util-deprecate": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/readdir-scoped-modules": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz",
+      "integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9749,6 +10350,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/request": {
       "version": "2.81.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+      "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -9782,6 +10385,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/request/node_modules/aws-sign2": {
       "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -9791,18 +10396,24 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/request/node_modules/aws4": {
       "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/request/node_modules/caseless": {
       "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0"
     },
     "node_modules/npx/node_modules/npm/node_modules/request/node_modules/combined-stream": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9815,6 +10426,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/request/node_modules/combined-stream/node_modules/delayed-stream": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9824,12 +10437,16 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/request/node_modules/extend": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/request/node_modules/forever-agent": {
       "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -9839,6 +10456,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/request/node_modules/form-data": {
       "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9853,12 +10472,16 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/request/node_modules/form-data/node_modules/asynckit": {
       "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/request/node_modules/har-validator": {
       "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+      "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9872,6 +10495,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/request/node_modules/har-validator/node_modules/ajv": {
       "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9882,6 +10507,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/request/node_modules/har-validator/node_modules/ajv/node_modules/co": {
       "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9892,6 +10519,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/request/node_modules/har-validator/node_modules/ajv/node_modules/json-stable-stringify": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9901,6 +10530,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/request/node_modules/har-validator/node_modules/ajv/node_modules/json-stable-stringify/node_modules/jsonify": {
       "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
       "dev": true,
       "inBundle": true,
       "license": "Public Domain",
@@ -9910,6 +10541,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/request/node_modules/har-validator/node_modules/har-schema": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+      "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9919,6 +10552,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/request/node_modules/hawk": {
       "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -9934,6 +10569,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/request/node_modules/hawk/node_modules/boom": {
       "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -9946,6 +10583,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/request/node_modules/hawk/node_modules/cryptiles": {
       "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -9958,6 +10597,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/request/node_modules/hawk/node_modules/hoek": {
       "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -9967,6 +10608,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/request/node_modules/hawk/node_modules/sntp": {
       "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
       "dev": true,
       "inBundle": true,
       "dependencies": {
@@ -9978,6 +10621,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/request/node_modules/http-signature": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9993,6 +10638,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/request/node_modules/http-signature/node_modules/assert-plus": {
       "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10002,6 +10649,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/request/node_modules/http-signature/node_modules/jsprim": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+      "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
       "dev": true,
       "engines": [
         "node >=0.6.0"
@@ -10017,6 +10666,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/request/node_modules/http-signature/node_modules/jsprim/node_modules/assert-plus": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10026,6 +10677,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/request/node_modules/http-signature/node_modules/jsprim/node_modules/extsprintf": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
       "dev": true,
       "engines": [
         "node >=0.6.0"
@@ -10034,11 +10687,15 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/request/node_modules/http-signature/node_modules/jsprim/node_modules/json-schema": {
       "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true,
       "inBundle": true
     },
     "node_modules/npx/node_modules/npm/node_modules/request/node_modules/http-signature/node_modules/jsprim/node_modules/verror": {
       "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
       "dev": true,
       "engines": [
         "node >=0.6.0"
@@ -10050,6 +10707,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/request/node_modules/http-signature/node_modules/sshpk": {
       "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10076,12 +10735,16 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/request/node_modules/http-signature/node_modules/sshpk/node_modules/asn1": {
       "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/request/node_modules/http-signature/node_modules/sshpk/node_modules/assert-plus": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10091,6 +10754,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/request/node_modules/http-signature/node_modules/sshpk/node_modules/bcrypt-pbkdf": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -10101,6 +10766,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/request/node_modules/http-signature/node_modules/sshpk/node_modules/dashdash": {
       "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10113,6 +10780,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/request/node_modules/http-signature/node_modules/sshpk/node_modules/ecc-jsbn": {
       "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10123,6 +10792,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/request/node_modules/http-signature/node_modules/sshpk/node_modules/getpass": {
       "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10132,6 +10803,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/request/node_modules/http-signature/node_modules/sshpk/node_modules/jsbn": {
       "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10139,6 +10812,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/request/node_modules/http-signature/node_modules/sshpk/node_modules/tweetnacl": {
       "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true,
       "inBundle": true,
       "license": "Unlicense",
@@ -10146,24 +10821,32 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/request/node_modules/is-typedarray": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/request/node_modules/isstream": {
       "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/request/node_modules/json-stringify-safe": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npx/node_modules/npm/node_modules/request/node_modules/mime-types": {
       "version": "2.1.15",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+      "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10176,6 +10859,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/request/node_modules/mime-types/node_modules/mime-db": {
       "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+      "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10185,6 +10870,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/request/node_modules/oauth-sign": {
       "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -10194,12 +10881,16 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/request/node_modules/performance-now": {
       "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+      "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/request/node_modules/qs": {
       "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+      "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -10209,12 +10900,16 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/request/node_modules/stringstream": {
       "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/request/node_modules/tough-cookie": {
       "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -10227,12 +10922,16 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/request/node_modules/tough-cookie/node_modules/punycode": {
       "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/request/node_modules/tunnel-agent": {
       "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -10245,6 +10944,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/retry": {
       "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
+      "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10254,6 +10955,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/rimraf": {
       "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10266,12 +10969,16 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/safe-buffer": {
       "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/semver": {
       "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10281,6 +10988,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/sha": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/sha/-/sha-2.0.1.tgz",
+      "integrity": "sha1-YDCCL70smCOUn49y7WQR7lzyWq4=",
       "dev": true,
       "inBundle": true,
       "license": "(BSD-2-Clause OR MIT)",
@@ -10291,6 +11000,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/slide": {
       "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10300,12 +11011,16 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/sorted-object": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/sorted-object/-/sorted-object-2.0.1.tgz",
+      "integrity": "sha1-fWMfS9OnmKJK8d/8+/6DM3pd9fw=",
       "dev": true,
       "inBundle": true,
       "license": "(WTFPL OR MIT)"
     },
     "node_modules/npx/node_modules/npm/node_modules/sorted-union-stream": {
       "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/sorted-union-stream/-/sorted-union-stream-2.1.3.tgz",
+      "integrity": "sha1-x3lMfgd4gAUv9xqNSi27Sppjisc=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10316,6 +11031,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/sorted-union-stream/node_modules/from2": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/from2/-/from2-1.3.0.tgz",
+      "integrity": "sha1-iEE7qqX5pZfP3pIh2GmGzTwGHf0=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10326,6 +11043,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/sorted-union-stream/node_modules/from2/node_modules/readable-stream": {
       "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10338,24 +11057,32 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/sorted-union-stream/node_modules/from2/node_modules/readable-stream/node_modules/core-util-is": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/sorted-union-stream/node_modules/from2/node_modules/readable-stream/node_modules/isarray": {
       "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/sorted-union-stream/node_modules/from2/node_modules/readable-stream/node_modules/string_decoder": {
       "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/sorted-union-stream/node_modules/stream-iterate": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/stream-iterate/-/stream-iterate-1.2.0.tgz",
+      "integrity": "sha1-K9fHcpbBcCpGSIuK1B95hl7s1OE=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10366,12 +11093,16 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/sorted-union-stream/node_modules/stream-iterate/node_modules/stream-shift": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/ssri": {
       "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-4.1.6.tgz",
+      "integrity": "sha512-WUbCdgSAMQjTFZRWvSPpauryvREEA+Krn19rx67UlJEJx/M192ZHxMmJXjZ4tkdFm+Sb0SXGlENeQVlA5wY7kA==",
       "dev": true,
       "inBundle": true,
       "license": "CC0-1.0",
@@ -10381,6 +11112,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/strip-ansi": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10393,6 +11126,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/strip-ansi/node_modules/ansi-regex": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10402,6 +11137,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/tar": {
       "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10413,6 +11150,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/tar/node_modules/block-stream": {
       "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10425,12 +11164,16 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/text-table": {
       "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/uid-number": {
       "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+      "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10440,12 +11183,16 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/umask": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
+      "integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/unique-filename": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
+      "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10455,6 +11202,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/unique-filename/node_modules/unique-slug": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
+      "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10464,6 +11213,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/unpipe": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10473,6 +11224,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.2.0.tgz",
+      "integrity": "sha1-G1g3z5DAc22IYncytmHBOPht5y8=",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -10492,6 +11245,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/boxen": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.1.0.tgz",
+      "integrity": "sha1-sbad1SIwXoB6md7ud329blFnsQI=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10510,6 +11265,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/boxen/node_modules/ansi-align": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
+      "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10519,6 +11276,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/boxen/node_modules/camelcase": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10528,6 +11287,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/boxen/node_modules/cli-boxes": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10537,6 +11298,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/boxen/node_modules/string-width": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.0.tgz",
+      "integrity": "sha1-AwZkVh/BRslCPsfZeP4kV0N/5tA=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10550,6 +11313,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/boxen/node_modules/string-width/node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10559,6 +11324,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/boxen/node_modules/string-width/node_modules/strip-ansi": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10571,6 +11338,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/boxen/node_modules/term-size": {
       "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/term-size/-/term-size-0.1.1.tgz",
+      "integrity": "sha1-hzYLljlsq1dgljcUzaDQy+7K2co=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10583,6 +11352,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/boxen/node_modules/term-size/node_modules/execa": {
       "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.4.0.tgz",
+      "integrity": "sha1-TrZGejaglfq7KXD/nV4/t7zm68M=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10600,6 +11371,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/boxen/node_modules/term-size/node_modules/execa/node_modules/cross-spawn-async": {
       "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz",
+      "integrity": "sha1-hF/wwINKPe2dFg2sptOQkGuyiMw=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10610,6 +11383,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/boxen/node_modules/term-size/node_modules/execa/node_modules/is-stream": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10619,6 +11394,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/boxen/node_modules/term-size/node_modules/execa/node_modules/npm-run-path": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
+      "integrity": "sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10631,6 +11408,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/boxen/node_modules/term-size/node_modules/execa/node_modules/object-assign": {
       "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10640,6 +11419,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/boxen/node_modules/term-size/node_modules/execa/node_modules/path-key": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-1.0.0.tgz",
+      "integrity": "sha1-XVPVeAGWRsDWiADbThRua9wqx68=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10649,6 +11430,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/boxen/node_modules/term-size/node_modules/execa/node_modules/strip-eof": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10658,6 +11441,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/boxen/node_modules/widest-line": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
+      "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10670,6 +11455,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/boxen/node_modules/widest-line/node_modules/string-width": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10684,6 +11471,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/boxen/node_modules/widest-line/node_modules/string-width/node_modules/code-point-at": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10693,6 +11482,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/boxen/node_modules/widest-line/node_modules/string-width/node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10705,6 +11496,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/boxen/node_modules/widest-line/node_modules/string-width/node_modules/is-fullwidth-code-point/node_modules/number-is-nan": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10714,6 +11507,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/boxen/node_modules/widest-line/node_modules/string-width/node_modules/strip-ansi": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10726,6 +11521,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/boxen/node_modules/widest-line/node_modules/string-width/node_modules/strip-ansi/node_modules/ansi-regex": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10735,6 +11532,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/chalk": {
       "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10751,6 +11550,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/chalk/node_modules/ansi-styles": {
       "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10760,6 +11561,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/chalk/node_modules/escape-string-regexp": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10769,6 +11572,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/chalk/node_modules/has-ansi": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10781,6 +11586,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/chalk/node_modules/has-ansi/node_modules/ansi-regex": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10790,6 +11597,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/chalk/node_modules/strip-ansi": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10802,6 +11611,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/chalk/node_modules/strip-ansi/node_modules/ansi-regex": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10811,6 +11622,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/chalk/node_modules/supports-color": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10820,6 +11633,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/configstore": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.0.tgz",
+      "integrity": "sha1-Rd+QcHPibfoc9LLVL1tgVF6qEdE=",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -10837,6 +11652,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/configstore/node_modules/dot-prop": {
       "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.1.1.tgz",
+      "integrity": "sha1-qEk/C3te7sglJbXHWH+n3nyoWcE=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10849,6 +11666,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/configstore/node_modules/dot-prop/node_modules/is-obj": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10858,6 +11677,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/configstore/node_modules/make-dir": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.0.0.tgz",
+      "integrity": "sha1-l6ARdR6R3YfPre9Ygy67BJNt6Xg=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10870,6 +11691,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/configstore/node_modules/make-dir/node_modules/pify": {
       "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10879,6 +11702,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/configstore/node_modules/unique-string": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+      "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10891,6 +11716,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/configstore/node_modules/unique-string/node_modules/crypto-random-string": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10900,6 +11727,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/import-lazy": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+      "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10909,6 +11738,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/is-npm": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+      "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10918,6 +11749,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/latest-version": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
+      "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10930,6 +11763,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
+      "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10945,6 +11780,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/got": {
       "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+      "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10967,6 +11804,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/got/node_modules/create-error-class": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10979,6 +11818,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/got/node_modules/create-error-class/node_modules/capture-stack-trace": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
+      "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10988,12 +11829,16 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/got/node_modules/duplexer3": {
       "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/got/node_modules/get-stream": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11003,6 +11848,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/got/node_modules/is-redirect": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11012,6 +11859,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/got/node_modules/is-retry-allowed": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11021,6 +11870,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/got/node_modules/is-stream": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11030,6 +11881,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/got/node_modules/lowercase-keys": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+      "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11039,6 +11892,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/got/node_modules/timed-out": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11048,6 +11903,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/got/node_modules/unzip-response": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
+      "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11057,6 +11914,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/got/node_modules/url-parse-lax": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11069,6 +11928,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/got/node_modules/url-parse-lax/node_modules/prepend-http": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11078,6 +11939,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/registry-auth-token": {
       "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz",
+      "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11088,6 +11951,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/registry-auth-token/node_modules/rc": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+      "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
       "dev": true,
       "inBundle": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
@@ -11103,6 +11968,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/registry-auth-token/node_modules/rc/node_modules/deep-extend": {
       "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11113,12 +11980,16 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/registry-auth-token/node_modules/rc/node_modules/minimist": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/registry-auth-token/node_modules/rc/node_modules/strip-json-comments": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11128,6 +11999,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/registry-url": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11140,6 +12013,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/registry-url/node_modules/rc": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+      "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
       "dev": true,
       "inBundle": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
@@ -11155,6 +12030,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/registry-url/node_modules/rc/node_modules/deep-extend": {
       "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11165,12 +12042,16 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/registry-url/node_modules/rc/node_modules/minimist": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/registry-url/node_modules/rc/node_modules/strip-json-comments": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11180,6 +12061,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/semver-diff": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+      "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11192,6 +12075,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/update-notifier/node_modules/xdg-basedir": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+      "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11201,6 +12086,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/uuid": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11210,6 +12097,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/validate-npm-package-license": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -11220,6 +12109,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/validate-npm-package-license/node_modules/spdx-correct": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -11229,18 +12120,24 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/validate-npm-package-license/node_modules/spdx-correct/node_modules/spdx-license-ids": {
       "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
       "dev": true,
       "inBundle": true,
       "license": "Unlicense"
     },
     "node_modules/npx/node_modules/npm/node_modules/validate-npm-package-license/node_modules/spdx-expression-parse": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
       "dev": true,
       "inBundle": true,
       "license": "(MIT AND CC-BY-3.0)"
     },
     "node_modules/npx/node_modules/npm/node_modules/validate-npm-package-name": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+      "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11250,12 +12147,16 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/validate-npm-package-name/node_modules/builtins": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
+      "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/which": {
       "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+      "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11268,12 +12169,16 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/which/node_modules/isexe": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npx/node_modules/npm/node_modules/worker-farm": {
       "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.3.1.tgz",
+      "integrity": "sha1-QzMRK7SbF6oFC4eJXKayys9A5f8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11284,6 +12189,8 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/worker-farm/node_modules/errno": {
       "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
+      "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11296,12 +12203,16 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/worker-farm/node_modules/errno/node_modules/prr": {
       "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
+      "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/npm/node_modules/worker-farm/node_modules/xtend": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
       "dev": true,
       "inBundle": true,
       "engines": {
@@ -11310,12 +12221,16 @@
     },
     "node_modules/npx/node_modules/npm/node_modules/wrappy": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npx/node_modules/npm/node_modules/write-file-atomic": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.1.0.tgz",
+      "integrity": "sha512-0TZ20a+xcIl4u0+Mj5xDH2yOWdmQiXlKf9Hm+TgDXjTMsEYb+gDrmb8e8UNAzMCitX8NBqG4Z/FUQIyzv/R1JQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11327,6 +12242,8 @@
     },
     "node_modules/npx/node_modules/number-is-nan": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11336,6 +12253,8 @@
     },
     "node_modules/npx/node_modules/once": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11345,6 +12264,8 @@
     },
     "node_modules/npx/node_modules/os-homedir": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11354,6 +12275,8 @@
     },
     "node_modules/npx/node_modules/os-locale": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+      "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11368,6 +12291,8 @@
     },
     "node_modules/npx/node_modules/os-locale/node_modules/cross-spawn": {
       "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11384,6 +12309,8 @@
     },
     "node_modules/npx/node_modules/os-locale/node_modules/execa": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11402,6 +12329,8 @@
     },
     "node_modules/npx/node_modules/os-locale/node_modules/get-stream": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11414,6 +12343,8 @@
     },
     "node_modules/npx/node_modules/os-tmpdir": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11423,6 +12354,8 @@
     },
     "node_modules/npx/node_modules/osenv": {
       "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11433,6 +12366,8 @@
     },
     "node_modules/npx/node_modules/p-defer": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11442,6 +12377,8 @@
     },
     "node_modules/npx/node_modules/p-finally": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11451,6 +12388,8 @@
     },
     "node_modules/npx/node_modules/p-is-promise": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
+      "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11460,6 +12399,8 @@
     },
     "node_modules/npx/node_modules/p-limit": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11472,6 +12413,8 @@
     },
     "node_modules/npx/node_modules/p-locate": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11484,6 +12427,8 @@
     },
     "node_modules/npx/node_modules/p-try": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11493,6 +12438,8 @@
     },
     "node_modules/npx/node_modules/package-json": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
+      "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11508,6 +12455,8 @@
     },
     "node_modules/npx/node_modules/path-exists": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11517,6 +12466,8 @@
     },
     "node_modules/npx/node_modules/path-is-absolute": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11526,12 +12477,16 @@
     },
     "node_modules/npx/node_modules/path-is-inside": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true,
       "inBundle": true,
       "license": "(WTFPL OR MIT)"
     },
     "node_modules/npx/node_modules/path-key": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11541,6 +12496,8 @@
     },
     "node_modules/npx/node_modules/pify": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11550,6 +12507,8 @@
     },
     "node_modules/npx/node_modules/prepend-http": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11559,12 +12518,16 @@
     },
     "node_modules/npx/node_modules/pseudomap": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npx/node_modules/pump": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11575,6 +12538,8 @@
     },
     "node_modules/npx/node_modules/rc": {
       "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "dev": true,
       "inBundle": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
@@ -11590,6 +12555,8 @@
     },
     "node_modules/npx/node_modules/registry-auth-token": {
       "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
+      "integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11600,6 +12567,8 @@
     },
     "node_modules/npx/node_modules/registry-url": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11612,6 +12581,8 @@
     },
     "node_modules/npx/node_modules/require-directory": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11621,12 +12592,16 @@
     },
     "node_modules/npx/node_modules/require-main-filename": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npx/node_modules/rimraf": {
       "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11639,12 +12614,16 @@
     },
     "node_modules/npx/node_modules/safe-buffer": {
       "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npx/node_modules/semver": {
       "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11654,6 +12633,8 @@
     },
     "node_modules/npx/node_modules/semver-diff": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+      "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11666,12 +12647,16 @@
     },
     "node_modules/npx/node_modules/set-blocking": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npx/node_modules/shebang-command": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11684,6 +12669,8 @@
     },
     "node_modules/npx/node_modules/shebang-regex": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11693,12 +12680,16 @@
     },
     "node_modules/npx/node_modules/signal-exit": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npx/node_modules/string-width": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11712,6 +12703,8 @@
     },
     "node_modules/npx/node_modules/strip-ansi": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11724,6 +12717,8 @@
     },
     "node_modules/npx/node_modules/strip-eof": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11733,6 +12728,8 @@
     },
     "node_modules/npx/node_modules/strip-json-comments": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11742,6 +12739,8 @@
     },
     "node_modules/npx/node_modules/supports-color": {
       "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11754,6 +12753,8 @@
     },
     "node_modules/npx/node_modules/term-size": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
+      "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11766,6 +12767,8 @@
     },
     "node_modules/npx/node_modules/timed-out": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11775,6 +12778,8 @@
     },
     "node_modules/npx/node_modules/unique-string": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+      "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11787,6 +12792,8 @@
     },
     "node_modules/npx/node_modules/unzip-response": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
+      "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11796,6 +12803,8 @@
     },
     "node_modules/npx/node_modules/update-notifier": {
       "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
+      "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -11817,6 +12826,8 @@
     },
     "node_modules/npx/node_modules/url-parse-lax": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11829,6 +12840,8 @@
     },
     "node_modules/npx/node_modules/validate-npm-package-name": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+      "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11838,6 +12851,8 @@
     },
     "node_modules/npx/node_modules/which": {
       "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11850,12 +12865,16 @@
     },
     "node_modules/npx/node_modules/which-module": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npx/node_modules/widest-line": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
+      "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11868,6 +12887,8 @@
     },
     "node_modules/npx/node_modules/wrap-ansi": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11881,6 +12902,8 @@
     },
     "node_modules/npx/node_modules/wrap-ansi/node_modules/ansi-regex": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11890,6 +12913,8 @@
     },
     "node_modules/npx/node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11902,6 +12927,8 @@
     },
     "node_modules/npx/node_modules/wrap-ansi/node_modules/string-width": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11916,6 +12943,8 @@
     },
     "node_modules/npx/node_modules/wrap-ansi/node_modules/strip-ansi": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11928,12 +12957,16 @@
     },
     "node_modules/npx/node_modules/wrappy": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npx/node_modules/write-file-atomic": {
       "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+      "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11945,6 +12978,8 @@
     },
     "node_modules/npx/node_modules/xdg-basedir": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+      "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11954,18 +12989,24 @@
     },
     "node_modules/npx/node_modules/y18n": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npx/node_modules/yallist": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npx/node_modules/yargs": {
       "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.1.tgz",
+      "integrity": "sha512-PRU7gJrJaXv3q3yQZ/+/X6KBswZiaQ+zOmdprZcouPYtQgvNU35i+68M4b1ZHLZtYFT5QObFLV+ZkmJYcwKdiw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11986,6 +13027,8 @@
     },
     "node_modules/npx/node_modules/yargs-parser": {
       "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
+      "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11995,6 +13038,8 @@
     },
     "node_modules/npx/node_modules/yargs/node_modules/y18n": {
       "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
@@ -16356,6 +17401,11 @@
         "buffer-equal": "^1.0.0"
       }
     },
+    "arch": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
+      "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ=="
+    },
     "archy": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
@@ -17122,6 +18172,16 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
       "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw=="
+    },
+    "clipboardy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-3.0.0.tgz",
+      "integrity": "sha512-Su+uU5sr1jkUy1sGRpLKjKrvEOVXgSgiSInwa/qeID6aJ07yh+5NWc3h2QfjHjBnfX4LhtFcuAWKUsJ3r+fjbg==",
+      "requires": {
+        "arch": "^2.2.0",
+        "execa": "^5.1.1",
+        "is-wsl": "^2.2.0"
+      }
     },
     "cliui": {
       "version": "3.2.0",
@@ -18783,7 +19843,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.14.7",
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.3.tgz",
+      "integrity": "sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA==",
       "dev": true
     },
     "for-in": {
@@ -19981,6 +21043,11 @@
         }
       }
     },
+    "is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="
+    },
     "is-elevated": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-elevated/-/is-elevated-4.0.0.tgz",
@@ -20190,6 +21257,14 @@
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
       "dev": true
+    },
+    "is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "requires": {
+        "is-docker": "^2.0.0"
+      }
     },
     "isarray": {
       "version": "1.0.0",
@@ -20955,7 +22030,9 @@
       "optional": true
     },
     "nanoid": {
-      "version": "3.1.31",
+      "version": "3.1.30",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.30.tgz",
+      "integrity": "sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==",
       "dev": true
     },
     "nanomatch": {
@@ -21104,6 +22181,8 @@
       "dependencies": {
         "ansi-align": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
+          "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21112,11 +22191,15 @@
         },
         "ansi-regex": {
           "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "bundled": true,
           "dev": true
         },
         "ansi-styles": {
           "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21125,11 +22208,15 @@
         },
         "balanced-match": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "bundled": true,
           "dev": true
         },
         "boxen": {
           "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
+          "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21144,6 +22231,8 @@
         },
         "brace-expansion": {
           "version": "1.1.11",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21153,21 +22242,29 @@
         },
         "builtins": {
           "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
+          "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
           "bundled": true,
           "dev": true
         },
         "camelcase": {
           "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
           "bundled": true,
           "dev": true
         },
         "capture-stack-trace": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
+          "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==",
           "bundled": true,
           "dev": true
         },
         "chalk": {
           "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21178,16 +22275,22 @@
         },
         "ci-info": {
           "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
+          "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
           "bundled": true,
           "dev": true
         },
         "cli-boxes": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+          "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
           "bundled": true,
           "dev": true
         },
         "cliui": {
           "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+          "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21198,11 +22301,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "bundled": true,
           "dev": true
         },
         "color-convert": {
           "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21211,16 +22318,22 @@
         },
         "color-name": {
           "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
           "bundled": true,
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "bundled": true,
           "dev": true
         },
         "configstore": {
           "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
+          "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21234,6 +22347,8 @@
         },
         "create-error-class": {
           "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+          "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21242,6 +22357,8 @@
         },
         "cross-spawn": {
           "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21252,21 +22369,29 @@
         },
         "crypto-random-string": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+          "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
           "bundled": true,
           "dev": true
         },
         "decamelize": {
           "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
           "bundled": true,
           "dev": true
         },
         "deep-extend": {
           "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "bundled": true,
           "dev": true
         },
         "dot-prop": {
           "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+          "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21275,16 +22400,22 @@
         },
         "dotenv": {
           "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
+          "integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow==",
           "bundled": true,
           "dev": true
         },
         "duplexer3": {
           "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+          "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
           "bundled": true,
           "dev": true
         },
         "end-of-stream": {
           "version": "1.4.4",
+          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+          "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21293,11 +22424,15 @@
         },
         "escape-string-regexp": {
           "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
           "bundled": true,
           "dev": true
         },
         "execa": {
           "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21312,6 +22447,8 @@
         },
         "find-up": {
           "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21320,21 +22457,29 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "bundled": true,
           "dev": true
         },
         "get-caller-file": {
           "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+          "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
           "bundled": true,
           "dev": true
         },
         "get-stream": {
           "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "bundled": true,
           "dev": true
         },
         "glob": {
           "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21348,6 +22493,8 @@
         },
         "global-dirs": {
           "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+          "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21356,6 +22503,8 @@
         },
         "got": {
           "version": "6.7.1",
+          "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+          "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21374,31 +22523,43 @@
         },
         "graceful-fs": {
           "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+          "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
           "bundled": true,
           "dev": true
         },
         "has-flag": {
           "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "bundled": true,
           "dev": true
         },
         "hosted-git-info": {
           "version": "2.8.5",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
+          "integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==",
           "bundled": true,
           "dev": true
         },
         "import-lazy": {
           "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+          "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
           "bundled": true,
           "dev": true
         },
         "imurmurhash": {
           "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
           "bundled": true,
           "dev": true
         },
         "inflight": {
           "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21408,21 +22569,29 @@
         },
         "inherits": {
           "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
           "bundled": true,
           "dev": true
         },
         "ini": {
           "version": "1.3.5",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "bundled": true,
           "dev": true
         },
         "invert-kv": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+          "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
           "bundled": true,
           "dev": true
         },
         "is-ci": {
           "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
+          "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21431,11 +22600,15 @@
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "bundled": true,
           "dev": true
         },
         "is-installed-globally": {
           "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+          "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21445,16 +22618,22 @@
         },
         "is-npm": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+          "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
           "bundled": true,
           "dev": true
         },
         "is-obj": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+          "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
           "bundled": true,
           "dev": true
         },
         "is-path-inside": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+          "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21463,26 +22642,36 @@
         },
         "is-redirect": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+          "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
           "bundled": true,
           "dev": true
         },
         "is-retry-allowed": {
           "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+          "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
           "bundled": true,
           "dev": true
         },
         "is-stream": {
           "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
           "bundled": true,
           "dev": true
         },
         "isexe": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
           "bundled": true,
           "dev": true
         },
         "latest-version": {
           "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
+          "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21491,6 +22680,8 @@
         },
         "lcid": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+          "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21499,6 +22690,8 @@
         },
         "libnpx": {
           "version": "10.2.2",
+          "resolved": "https://registry.npmjs.org/libnpx/-/libnpx-10.2.2.tgz",
+          "integrity": "sha512-ujaYToga1SAX5r7FU5ShMFi88CWpY75meNZtr6RtEyv4l2ZK3+Wgvxq2IqlwWBiDZOqhumdeiocPS1aKrCMe3A==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21514,6 +22707,8 @@
         },
         "locate-path": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21523,11 +22718,15 @@
         },
         "lowercase-keys": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+          "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
           "bundled": true,
           "dev": true
         },
         "lru-cache": {
           "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21537,6 +22736,8 @@
         },
         "make-dir": {
           "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+          "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21545,6 +22746,8 @@
         },
         "map-age-cleaner": {
           "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+          "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21553,6 +22756,8 @@
         },
         "mem": {
           "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+          "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21563,11 +22768,15 @@
         },
         "mimic-fn": {
           "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
           "bundled": true,
           "dev": true
         },
         "minimatch": {
           "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21576,16 +22785,22 @@
         },
         "minimist": {
           "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "bundled": true,
           "dev": true
         },
         "nice-try": {
           "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+          "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
           "bundled": true,
           "dev": true
         },
         "npm": {
           "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/npm/-/npm-5.1.0.tgz",
+          "integrity": "sha512-pt5ClxEmY/dLpb60SmGQQBKi3nB6Ljx1FXmpoCUdAULlGqGVn2uCyXxPCWFbcuHGthT7qGiaGa1wOfs/UjGYMw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21689,41 +22904,57 @@
           "dependencies": {
             "abbrev": {
               "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+              "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
               "bundled": true,
               "dev": true
             },
             "ansi-regex": {
               "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
               "bundled": true,
               "dev": true
             },
             "ansicolors": {
               "version": "0.3.2",
+              "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
+              "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
               "bundled": true,
               "dev": true
             },
             "ansistyles": {
               "version": "0.1.3",
+              "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
+              "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk=",
               "bundled": true,
               "dev": true
             },
             "aproba": {
               "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz",
+              "integrity": "sha512-ZpYajIfO0j2cOFTO955KUMIKNmj6zhX8kVztMAxFsDaMwz+9Z9SV0uou2pC9HJqcfpffOsjnbrDMvkNy+9RXPw==",
               "bundled": true,
               "dev": true
             },
             "archy": {
               "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+              "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
               "bundled": true,
               "dev": true
             },
             "bluebird": {
               "version": "3.5.0",
+              "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+              "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
               "bundled": true,
               "dev": true
             },
             "cacache": {
               "version": "9.2.9",
+              "resolved": "https://registry.npmjs.org/cacache/-/cacache-9.2.9.tgz",
+              "integrity": "sha512-ghg1j5OyTJ6qsrqU++dN23QiTDxb5AZCFGsF3oB+v9v/gY+F4X8L/0gdQMEjd+8Ot3D29M2etX5PKozHRn2JQw==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -21744,6 +22975,8 @@
               "dependencies": {
                 "lru-cache": {
                   "version": "4.1.1",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+                  "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -21753,11 +22986,15 @@
                   "dependencies": {
                     "pseudomap": {
                       "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+                      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
                       "bundled": true,
                       "dev": true
                     },
                     "yallist": {
                       "version": "2.1.2",
+                      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+                      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
                       "bundled": true,
                       "dev": true
                     }
@@ -21765,6 +23002,8 @@
                 },
                 "y18n": {
                   "version": "3.2.1",
+                  "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+                  "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
                   "bundled": true,
                   "dev": true
                 }
@@ -21772,16 +23011,22 @@
             },
             "call-limit": {
               "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/call-limit/-/call-limit-1.1.0.tgz",
+              "integrity": "sha1-b9YbA/PaQqLNDsK2DwK9DnGZH+o=",
               "bundled": true,
               "dev": true
             },
             "chownr": {
               "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+              "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
               "bundled": true,
               "dev": true
             },
             "cmd-shim": {
               "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
+              "integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -21791,6 +23036,8 @@
             },
             "columnify": {
               "version": "1.5.4",
+              "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
+              "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -21800,6 +23047,8 @@
               "dependencies": {
                 "strip-ansi": {
                   "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -21808,6 +23057,8 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.1.1",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                       "bundled": true,
                       "dev": true
                     }
@@ -21815,6 +23066,8 @@
                 },
                 "wcwidth": {
                   "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+                  "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -21823,6 +23076,8 @@
                   "dependencies": {
                     "defaults": {
                       "version": "1.0.3",
+                      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+                      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
                       "bundled": true,
                       "dev": true,
                       "requires": {
@@ -21831,6 +23086,8 @@
                       "dependencies": {
                         "clone": {
                           "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+                          "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
                           "bundled": true,
                           "dev": true
                         }
@@ -21842,6 +23099,8 @@
             },
             "config-chain": {
               "version": "1.1.11",
+              "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
+              "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -21851,6 +23110,8 @@
               "dependencies": {
                 "proto-list": {
                   "version": "1.2.4",
+                  "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+                  "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
                   "bundled": true,
                   "dev": true
                 }
@@ -21858,16 +23119,22 @@
             },
             "debuglog": {
               "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+              "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
               "bundled": true,
               "dev": true
             },
             "detect-indent": {
               "version": "5.0.0",
+              "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
+              "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
               "bundled": true,
               "dev": true
             },
             "dezalgo": {
               "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
+              "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -21877,6 +23144,8 @@
               "dependencies": {
                 "asap": {
                   "version": "2.0.5",
+                  "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz",
+                  "integrity": "sha1-UidltQw1EEkOUtfc/ghe+bqWlY8=",
                   "bundled": true,
                   "dev": true
                 }
@@ -21884,11 +23153,15 @@
             },
             "editor": {
               "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz",
+              "integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I=",
               "bundled": true,
               "dev": true
             },
             "fs-vacuum": {
               "version": "1.2.10",
+              "resolved": "https://registry.npmjs.org/fs-vacuum/-/fs-vacuum-1.2.10.tgz",
+              "integrity": "sha1-t2Kb7AekAxolSP35n17PHMizHjY=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -21899,6 +23172,8 @@
             },
             "fs-write-stream-atomic": {
               "version": "1.0.10",
+              "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+              "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -21910,6 +23185,8 @@
             },
             "fstream": {
               "version": "1.0.11",
+              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+              "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -21921,6 +23198,8 @@
             },
             "fstream-npm": {
               "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/fstream-npm/-/fstream-npm-1.2.1.tgz",
+              "integrity": "sha512-iBHpm/LmD1qw0TlHMAqVd9rwdU6M+EHRUnPkXpRi5G/Hf0FIFH+oZFryodAU2MFNfGRh/CzhUFlMKV3pdeOTDw==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -21930,6 +23209,8 @@
               "dependencies": {
                 "fstream-ignore": {
                   "version": "1.0.5",
+                  "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+                  "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -21940,6 +23221,8 @@
                   "dependencies": {
                     "minimatch": {
                       "version": "3.0.4",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                       "bundled": true,
                       "dev": true,
                       "requires": {
@@ -21948,6 +23231,8 @@
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.8",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                          "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
                           "bundled": true,
                           "dev": true,
                           "requires": {
@@ -21957,11 +23242,15 @@
                           "dependencies": {
                             "balanced-match": {
                               "version": "1.0.0",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
                               "bundled": true,
                               "dev": true
                             },
                             "concat-map": {
                               "version": "0.0.1",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                               "bundled": true,
                               "dev": true
                             }
@@ -21975,6 +23264,8 @@
             },
             "glob": {
               "version": "7.1.2",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+              "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -21988,11 +23279,15 @@
               "dependencies": {
                 "fs.realpath": {
                   "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+                  "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
                   "bundled": true,
                   "dev": true
                 },
                 "minimatch": {
                   "version": "3.0.4",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                  "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -22001,6 +23296,8 @@
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.8",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
                       "bundled": true,
                       "dev": true,
                       "requires": {
@@ -22010,11 +23307,15 @@
                       "dependencies": {
                         "balanced-match": {
                           "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
                           "bundled": true,
                           "dev": true
                         },
                         "concat-map": {
                           "version": "0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                           "bundled": true,
                           "dev": true
                         }
@@ -22024,6 +23325,8 @@
                 },
                 "path-is-absolute": {
                   "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+                  "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
                   "bundled": true,
                   "dev": true
                 }
@@ -22031,31 +23334,43 @@
             },
             "graceful-fs": {
               "version": "4.1.11",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+              "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
               "bundled": true,
               "dev": true
             },
             "has-unicode": {
               "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+              "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
               "bundled": true,
               "dev": true
             },
             "hosted-git-info": {
               "version": "2.5.0",
+              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+              "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
               "bundled": true,
               "dev": true
             },
             "iferr": {
               "version": "0.1.5",
+              "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+              "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
               "bundled": true,
               "dev": true
             },
             "imurmurhash": {
               "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+              "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
               "bundled": true,
               "dev": true
             },
             "inflight": {
               "version": "1.0.6",
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -22065,16 +23380,22 @@
             },
             "inherits": {
               "version": "2.0.3",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
               "bundled": true,
               "dev": true
             },
             "ini": {
               "version": "1.3.4",
+              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+              "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
               "bundled": true,
               "dev": true
             },
             "init-package-json": {
               "version": "1.10.1",
+              "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.10.1.tgz",
+              "integrity": "sha1-zYc6FneWvvuZYSsodioLY5P9j2o=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -22090,6 +23411,8 @@
               "dependencies": {
                 "promzard": {
                   "version": "0.3.0",
+                  "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
+                  "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -22100,6 +23423,8 @@
             },
             "JSONStream": {
               "version": "1.3.1",
+              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+              "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -22109,11 +23434,15 @@
               "dependencies": {
                 "jsonparse": {
                   "version": "1.3.1",
+                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+                  "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
                   "bundled": true,
                   "dev": true
                 },
                 "through": {
                   "version": "2.3.8",
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+                  "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
                   "bundled": true,
                   "dev": true
                 }
@@ -22121,21 +23450,29 @@
             },
             "lazy-property": {
               "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/lazy-property/-/lazy-property-1.0.0.tgz",
+              "integrity": "sha1-hN3Es3Bnm6i9TNz6TAa0PVcREUc=",
               "bundled": true,
               "dev": true
             },
             "lockfile": {
               "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.3.tgz",
+              "integrity": "sha1-Jjj8OaAzHpysGgS3F5mTHJxQ33k=",
               "bundled": true,
               "dev": true
             },
             "lodash._baseindexof": {
               "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
+              "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=",
               "bundled": true,
               "dev": true
             },
             "lodash._baseuniq": {
               "version": "4.6.0",
+              "resolved": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz",
+              "integrity": "sha1-DrtE5FaBSveQXGIS+iybLVG4Qeg=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -22145,11 +23482,15 @@
               "dependencies": {
                 "lodash._createset": {
                   "version": "4.0.3",
+                  "resolved": "https://registry.npmjs.org/lodash._createset/-/lodash._createset-4.0.3.tgz",
+                  "integrity": "sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=",
                   "bundled": true,
                   "dev": true
                 },
                 "lodash._root": {
                   "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+                  "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
                   "bundled": true,
                   "dev": true
                 }
@@ -22157,16 +23498,22 @@
             },
             "lodash._bindcallback": {
               "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+              "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
               "bundled": true,
               "dev": true
             },
             "lodash._cacheindexof": {
               "version": "3.0.2",
+              "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
+              "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=",
               "bundled": true,
               "dev": true
             },
             "lodash._createcache": {
               "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
+              "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -22175,36 +23522,50 @@
             },
             "lodash._getnative": {
               "version": "3.9.1",
+              "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+              "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
               "bundled": true,
               "dev": true
             },
             "lodash.clonedeep": {
               "version": "4.5.0",
+              "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+              "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
               "bundled": true,
               "dev": true
             },
             "lodash.restparam": {
               "version": "3.6.1",
+              "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+              "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
               "bundled": true,
               "dev": true
             },
             "lodash.union": {
               "version": "4.6.0",
+              "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+              "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
               "bundled": true,
               "dev": true
             },
             "lodash.uniq": {
               "version": "4.5.0",
+              "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+              "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
               "bundled": true,
               "dev": true
             },
             "lodash.without": {
               "version": "4.4.0",
+              "resolved": "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz",
+              "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw=",
               "bundled": true,
               "dev": true
             },
             "lru-cache": {
               "version": "4.1.1",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+              "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -22214,11 +23575,15 @@
               "dependencies": {
                 "pseudomap": {
                   "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+                  "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
                   "bundled": true,
                   "dev": true
                 },
                 "yallist": {
                   "version": "2.1.2",
+                  "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+                  "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
                   "bundled": true,
                   "dev": true
                 }
@@ -22226,6 +23591,8 @@
             },
             "mississippi": {
               "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-1.3.0.tgz",
+              "integrity": "sha1-0gFYPrEjJ+PFwWQqQEqcrPlONPU=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -22243,6 +23610,8 @@
               "dependencies": {
                 "concat-stream": {
                   "version": "1.6.0",
+                  "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+                  "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -22253,6 +23622,8 @@
                   "dependencies": {
                     "typedarray": {
                       "version": "0.0.6",
+                      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
                       "bundled": true,
                       "dev": true
                     }
@@ -22260,6 +23631,8 @@
                 },
                 "duplexify": {
                   "version": "3.5.0",
+                  "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz",
+                  "integrity": "sha1-GqdzAC4VeEV+nZ1KULDMquvL1gQ=",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -22271,6 +23644,8 @@
                   "dependencies": {
                     "end-of-stream": {
                       "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+                      "integrity": "sha1-1FlucCc0qT5A6a+GQxnqvZn/Lw4=",
                       "bundled": true,
                       "dev": true,
                       "requires": {
@@ -22279,6 +23654,8 @@
                       "dependencies": {
                         "once": {
                           "version": "1.3.3",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                          "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
                           "bundled": true,
                           "dev": true,
                           "requires": {
@@ -22289,6 +23666,8 @@
                     },
                     "stream-shift": {
                       "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+                      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
                       "bundled": true,
                       "dev": true
                     }
@@ -22296,6 +23675,8 @@
                 },
                 "end-of-stream": {
                   "version": "1.4.0",
+                  "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
+                  "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -22304,6 +23685,8 @@
                 },
                 "flush-write-stream": {
                   "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.2.tgz",
+                  "integrity": "sha1-yBuQ2HRnZvGmCaRoCZRsRd2K5Bc=",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -22313,6 +23696,8 @@
                 },
                 "from2": {
                   "version": "2.3.0",
+                  "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+                  "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -22322,6 +23707,8 @@
                 },
                 "parallel-transform": {
                   "version": "1.1.0",
+                  "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
+                  "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -22332,6 +23719,8 @@
                   "dependencies": {
                     "cyclist": {
                       "version": "0.2.2",
+                      "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
+                      "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
                       "bundled": true,
                       "dev": true
                     }
@@ -22339,6 +23728,8 @@
                 },
                 "pump": {
                   "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz",
+                  "integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -22348,6 +23739,8 @@
                 },
                 "pumpify": {
                   "version": "1.3.5",
+                  "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.5.tgz",
+                  "integrity": "sha1-G2ccYZlAq8rqwK0OOjwWS+dgmTs=",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -22358,6 +23751,8 @@
                 },
                 "stream-each": {
                   "version": "1.2.0",
+                  "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.0.tgz",
+                  "integrity": "sha1-HpXUdXP1gNgU3A/4zQ9m8c5TyZE=",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -22367,6 +23762,8 @@
                   "dependencies": {
                     "stream-shift": {
                       "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+                      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
                       "bundled": true,
                       "dev": true
                     }
@@ -22374,6 +23771,8 @@
                 },
                 "through2": {
                   "version": "2.0.3",
+                  "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+                  "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -22383,6 +23782,8 @@
                   "dependencies": {
                     "xtend": {
                       "version": "4.0.1",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
                       "bundled": true,
                       "dev": true
                     }
@@ -22392,6 +23793,8 @@
             },
             "mkdirp": {
               "version": "0.5.1",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -22400,6 +23803,8 @@
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
                   "bundled": true,
                   "dev": true
                 }
@@ -22407,6 +23812,8 @@
             },
             "move-concurrently": {
               "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
+              "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -22420,6 +23827,8 @@
               "dependencies": {
                 "copy-concurrently": {
                   "version": "1.0.3",
+                  "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.3.tgz",
+                  "integrity": "sha1-Rft4ZiSaHKiJqlcI5svSc+dbslA=",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -22433,6 +23842,8 @@
                 },
                 "run-queue": {
                   "version": "1.0.3",
+                  "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
+                  "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -22443,6 +23854,8 @@
             },
             "node-gyp": {
               "version": "3.6.2",
+              "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
+              "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -22463,6 +23876,8 @@
               "dependencies": {
                 "minimatch": {
                   "version": "3.0.4",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                  "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -22471,6 +23886,8 @@
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.8",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
                       "bundled": true,
                       "dev": true,
                       "requires": {
@@ -22480,11 +23897,15 @@
                       "dependencies": {
                         "balanced-match": {
                           "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
                           "bundled": true,
                           "dev": true
                         },
                         "concat-map": {
                           "version": "0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                           "bundled": true,
                           "dev": true
                         }
@@ -22494,6 +23915,8 @@
                 },
                 "nopt": {
                   "version": "3.0.6",
+                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+                  "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -22504,6 +23927,8 @@
             },
             "nopt": {
               "version": "4.0.1",
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+              "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -22513,6 +23938,8 @@
             },
             "normalize-package-data": {
               "version": "2.4.0",
+              "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+              "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -22524,6 +23951,8 @@
               "dependencies": {
                 "is-builtin-module": {
                   "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+                  "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -22532,6 +23961,8 @@
                   "dependencies": {
                     "builtin-modules": {
                       "version": "1.1.1",
+                      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+                      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
                       "bundled": true,
                       "dev": true
                     }
@@ -22541,11 +23972,15 @@
             },
             "npm-cache-filename": {
               "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz",
+              "integrity": "sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE=",
               "bundled": true,
               "dev": true
             },
             "npm-install-checks": {
               "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-3.0.0.tgz",
+              "integrity": "sha1-1K7N/VGlPjcjt7L5Oy7ijjB7wNc=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -22554,6 +23989,8 @@
             },
             "npm-package-arg": {
               "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-5.1.2.tgz",
+              "integrity": "sha512-wJBsrf0qpypPT7A0LART18hCdyhpCMxeTtcb0X4IZO2jsP6Om7EHN1d9KSKiqD+KVH030RVNpWS9thk+pb7wzA==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -22565,6 +24002,8 @@
             },
             "npm-registry-client": {
               "version": "8.4.0",
+              "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-8.4.0.tgz",
+              "integrity": "sha512-PVNfqq0lyRdFnE//nDmn3CC9uqTsr8Bya9KPLIevlXMfkP0m4RpCVyFFk0W1Gfx436kKwyhLA6J+lV+rgR81gQ==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -22583,6 +24022,8 @@
               "dependencies": {
                 "concat-stream": {
                   "version": "1.6.0",
+                  "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+                  "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -22593,6 +24034,8 @@
                   "dependencies": {
                     "typedarray": {
                       "version": "0.0.6",
+                      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
                       "bundled": true,
                       "dev": true
                     }
@@ -22602,11 +24045,15 @@
             },
             "npm-user-validate": {
               "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-1.0.0.tgz",
+              "integrity": "sha1-jOyg9c6gTU6TUZ73LQVXp1Ei6VE=",
               "bundled": true,
               "dev": true
             },
             "npmlog": {
               "version": "4.1.2",
+              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+              "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -22618,6 +24065,8 @@
               "dependencies": {
                 "are-we-there-yet": {
                   "version": "1.1.4",
+                  "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+                  "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -22627,6 +24076,8 @@
                   "dependencies": {
                     "delegates": {
                       "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+                      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
                       "bundled": true,
                       "dev": true
                     }
@@ -22634,11 +24085,15 @@
                 },
                 "console-control-strings": {
                   "version": "1.1.0",
+                  "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+                  "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
                   "bundled": true,
                   "dev": true
                 },
                 "gauge": {
                   "version": "2.7.4",
+                  "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+                  "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -22654,16 +24109,22 @@
                   "dependencies": {
                     "object-assign": {
                       "version": "4.1.1",
+                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+                      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
                       "bundled": true,
                       "dev": true
                     },
                     "signal-exit": {
                       "version": "3.0.2",
+                      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+                      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
                       "bundled": true,
                       "dev": true
                     },
                     "string-width": {
                       "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                       "bundled": true,
                       "dev": true,
                       "requires": {
@@ -22674,11 +24135,15 @@
                       "dependencies": {
                         "code-point-at": {
                           "version": "1.1.0",
+                          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+                          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
                           "bundled": true,
                           "dev": true
                         },
                         "is-fullwidth-code-point": {
                           "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                           "bundled": true,
                           "dev": true,
                           "requires": {
@@ -22687,6 +24152,8 @@
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.1",
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
                               "bundled": true,
                               "dev": true
                             }
@@ -22696,6 +24163,8 @@
                     },
                     "strip-ansi": {
                       "version": "3.0.1",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                       "bundled": true,
                       "dev": true,
                       "requires": {
@@ -22704,6 +24173,8 @@
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.1.1",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                           "bundled": true,
                           "dev": true
                         }
@@ -22711,6 +24182,8 @@
                     },
                     "wide-align": {
                       "version": "1.1.2",
+                      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+                      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
                       "bundled": true,
                       "dev": true,
                       "requires": {
@@ -22721,6 +24194,8 @@
                 },
                 "set-blocking": {
                   "version": "2.0.0",
+                  "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+                  "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
                   "bundled": true,
                   "dev": true
                 }
@@ -22728,6 +24203,8 @@
             },
             "once": {
               "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -22736,11 +24213,15 @@
             },
             "opener": {
               "version": "1.4.3",
+              "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.3.tgz",
+              "integrity": "sha1-XG2ixdflgx6P+jlklQ+NZnSskLg=",
               "bundled": true,
               "dev": true
             },
             "osenv": {
               "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+              "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -22750,11 +24231,15 @@
               "dependencies": {
                 "os-homedir": {
                   "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+                  "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
                   "bundled": true,
                   "dev": true
                 },
                 "os-tmpdir": {
                   "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+                  "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
                   "bundled": true,
                   "dev": true
                 }
@@ -22762,6 +24247,8 @@
             },
             "pacote": {
               "version": "2.7.38",
+              "resolved": "https://registry.npmjs.org/pacote/-/pacote-2.7.38.tgz",
+              "integrity": "sha512-XxHUyHQB7QCVBxoXeVu0yKxT+2PvJucsc0+1E+6f95lMUxEAYERgSAc71ckYXrYr35Ew3xFU/LrhdIK21GQFFA==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -22790,6 +24277,8 @@
               "dependencies": {
                 "make-fetch-happen": {
                   "version": "2.4.13",
+                  "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-2.4.13.tgz",
+                  "integrity": "sha512-73CsTlMRSLdGr7VvOE8iYl/ejOSIxyfRYg7jZhepGGEqIlgdq6FLe2DEAI5bo813Jdg5fS/Ku62SRQ/UpT6NJA==",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -22808,6 +24297,8 @@
                   "dependencies": {
                     "agentkeepalive": {
                       "version": "3.3.0",
+                      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.3.0.tgz",
+                      "integrity": "sha512-9yhcpXti2ZQE7bxuCsjjWNIZoQOd9sZ1ZBovHG0YeCRohFv73SLvcm73PC9T3olM4GyozaQb+4MGdQpcD8m7NQ==",
                       "bundled": true,
                       "dev": true,
                       "requires": {
@@ -22816,6 +24307,8 @@
                       "dependencies": {
                         "humanize-ms": {
                           "version": "1.2.1",
+                          "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+                          "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
                           "bundled": true,
                           "dev": true,
                           "requires": {
@@ -22824,6 +24317,8 @@
                           "dependencies": {
                             "ms": {
                               "version": "2.0.0",
+                              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
                               "bundled": true,
                               "dev": true
                             }
@@ -22833,11 +24328,15 @@
                     },
                     "http-cache-semantics": {
                       "version": "3.7.3",
+                      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.7.3.tgz",
+                      "integrity": "sha1-LzXFMuzSnx5UE7mvgztySjxvf3I=",
                       "bundled": true,
                       "dev": true
                     },
                     "http-proxy-agent": {
                       "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.0.0.tgz",
+                      "integrity": "sha1-RkgqLwUjpNYIJVFwn0acs+SoX/Q=",
                       "bundled": true,
                       "dev": true,
                       "requires": {
@@ -22847,6 +24346,8 @@
                       "dependencies": {
                         "agent-base": {
                           "version": "4.1.0",
+                          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.1.0.tgz",
+                          "integrity": "sha1-IOF0Ac1Js8B2v1akvGxbQ2/6jVU=",
                           "bundled": true,
                           "dev": true,
                           "requires": {
@@ -22855,6 +24356,8 @@
                           "dependencies": {
                             "es6-promisify": {
                               "version": "5.0.0",
+                              "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+                              "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
                               "bundled": true,
                               "dev": true,
                               "requires": {
@@ -22863,6 +24366,8 @@
                               "dependencies": {
                                 "es6-promise": {
                                   "version": "4.1.1",
+                                  "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
+                                  "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng==",
                                   "bundled": true,
                                   "dev": true
                                 }
@@ -22872,6 +24377,8 @@
                         },
                         "debug": {
                           "version": "2.6.8",
+                          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
                           "bundled": true,
                           "dev": true,
                           "requires": {
@@ -22880,6 +24387,8 @@
                           "dependencies": {
                             "ms": {
                               "version": "2.0.0",
+                              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
                               "bundled": true,
                               "dev": true
                             }
@@ -22889,6 +24398,8 @@
                     },
                     "https-proxy-agent": {
                       "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.0.0.tgz",
+                      "integrity": "sha1-/6pLb69YasNAwYoUBDHna31/KUQ=",
                       "bundled": true,
                       "dev": true,
                       "requires": {
@@ -22898,6 +24409,8 @@
                       "dependencies": {
                         "agent-base": {
                           "version": "4.1.0",
+                          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.1.0.tgz",
+                          "integrity": "sha1-IOF0Ac1Js8B2v1akvGxbQ2/6jVU=",
                           "bundled": true,
                           "dev": true,
                           "requires": {
@@ -22906,6 +24419,8 @@
                           "dependencies": {
                             "es6-promisify": {
                               "version": "5.0.0",
+                              "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+                              "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
                               "bundled": true,
                               "dev": true,
                               "requires": {
@@ -22914,6 +24429,8 @@
                               "dependencies": {
                                 "es6-promise": {
                                   "version": "4.1.1",
+                                  "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
+                                  "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng==",
                                   "bundled": true,
                                   "dev": true
                                 }
@@ -22923,6 +24440,8 @@
                         },
                         "debug": {
                           "version": "2.6.8",
+                          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
                           "bundled": true,
                           "dev": true,
                           "requires": {
@@ -22931,6 +24450,8 @@
                           "dependencies": {
                             "ms": {
                               "version": "2.0.0",
+                              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
                               "bundled": true,
                               "dev": true
                             }
@@ -22940,6 +24461,8 @@
                     },
                     "node-fetch-npm": {
                       "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.1.tgz",
+                      "integrity": "sha512-W3onhopST5tqpX0/MGSL47pDQLLKobNR83AvkiOWQKaw54h+uYUfzeLAxCiyhWlUOiuI+GIb4O9ojLaAFlhCCA==",
                       "bundled": true,
                       "dev": true,
                       "requires": {
@@ -22950,6 +24473,8 @@
                       "dependencies": {
                         "encoding": {
                           "version": "0.1.12",
+                          "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+                          "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
                           "bundled": true,
                           "dev": true,
                           "requires": {
@@ -22958,6 +24483,8 @@
                           "dependencies": {
                             "iconv-lite": {
                               "version": "0.4.18",
+                              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
+                              "integrity": "sha512-sr1ZQph3UwHTR0XftSbK85OvBbxe/abLGzEnPENCQwmHf7sck8Oyu4ob3LgBxWWxRoM+QszeUyl7jbqapu2TqA==",
                               "bundled": true,
                               "dev": true
                             }
@@ -22965,6 +24492,8 @@
                         },
                         "json-parse-helpfulerror": {
                           "version": "1.0.3",
+                          "resolved": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
+                          "integrity": "sha1-E/FM4C7tTpgSl7ZOueO5MuLdE9w=",
                           "bundled": true,
                           "dev": true,
                           "requires": {
@@ -22973,6 +24502,8 @@
                           "dependencies": {
                             "jju": {
                               "version": "1.3.0",
+                              "resolved": "https://registry.npmjs.org/jju/-/jju-1.3.0.tgz",
+                              "integrity": "sha1-2t2e8BkkvHKLA/L3l5vb1i96Kqo=",
                               "bundled": true,
                               "dev": true
                             }
@@ -22982,6 +24513,8 @@
                     },
                     "socks-proxy-agent": {
                       "version": "3.0.0",
+                      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-3.0.0.tgz",
+                      "integrity": "sha512-YJcT+SNNBgFoK/NpO20PChz0VnBOhkjG3X10BwlrYujd0NZlSsH1jbxSQ1S0njt3sOvzwQ2PvGqqUIvP4rNk/w==",
                       "bundled": true,
                       "dev": true,
                       "requires": {
@@ -22991,6 +24524,8 @@
                       "dependencies": {
                         "agent-base": {
                           "version": "4.1.0",
+                          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.1.0.tgz",
+                          "integrity": "sha1-IOF0Ac1Js8B2v1akvGxbQ2/6jVU=",
                           "bundled": true,
                           "dev": true,
                           "requires": {
@@ -22999,6 +24534,8 @@
                           "dependencies": {
                             "es6-promisify": {
                               "version": "5.0.0",
+                              "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+                              "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
                               "bundled": true,
                               "dev": true,
                               "requires": {
@@ -23007,6 +24544,8 @@
                               "dependencies": {
                                 "es6-promise": {
                                   "version": "4.1.1",
+                                  "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
+                                  "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng==",
                                   "bundled": true,
                                   "dev": true
                                 }
@@ -23016,6 +24555,8 @@
                         },
                         "socks": {
                           "version": "1.1.10",
+                          "resolved": "https://registry.npmjs.org/socks/-/socks-1.1.10.tgz",
+                          "integrity": "sha1-W4t/x8jzQcU+0FbpKbe/Tei6e1o=",
                           "bundled": true,
                           "dev": true,
                           "requires": {
@@ -23025,11 +24566,15 @@
                           "dependencies": {
                             "ip": {
                               "version": "1.1.5",
+                              "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+                              "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
                               "bundled": true,
                               "dev": true
                             },
                             "smart-buffer": {
                               "version": "1.1.15",
+                              "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-1.1.15.tgz",
+                              "integrity": "sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY=",
                               "bundled": true,
                               "dev": true
                             }
@@ -23041,6 +24586,8 @@
                 },
                 "minimatch": {
                   "version": "3.0.4",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                  "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -23049,6 +24596,8 @@
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.8",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
                       "bundled": true,
                       "dev": true,
                       "requires": {
@@ -23058,11 +24607,15 @@
                       "dependencies": {
                         "balanced-match": {
                           "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
                           "bundled": true,
                           "dev": true
                         },
                         "concat-map": {
                           "version": "0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                           "bundled": true,
                           "dev": true
                         }
@@ -23072,6 +24625,8 @@
                 },
                 "npm-pick-manifest": {
                   "version": "1.0.4",
+                  "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-1.0.4.tgz",
+                  "integrity": "sha512-MKxNdeyOZysPRTTbHtW0M5Fw38Jo/3ARsoGw5qjCfS+XGjvNB/Gb4qtAZUFmKPM2mVum+eX559eHvKywU856BQ==",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -23081,6 +24636,8 @@
                 },
                 "promise-retry": {
                   "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
+                  "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -23090,6 +24647,8 @@
                   "dependencies": {
                     "err-code": {
                       "version": "1.1.2",
+                      "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
+                      "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
                       "bundled": true,
                       "dev": true
                     }
@@ -23097,6 +24656,8 @@
                 },
                 "protoduck": {
                   "version": "4.0.0",
+                  "resolved": "https://registry.npmjs.org/protoduck/-/protoduck-4.0.0.tgz",
+                  "integrity": "sha1-/kh02MeRM2bP2erRJFOiLNNlf44=",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -23105,6 +24666,8 @@
                   "dependencies": {
                     "genfun": {
                       "version": "4.0.1",
+                      "resolved": "https://registry.npmjs.org/genfun/-/genfun-4.0.1.tgz",
+                      "integrity": "sha1-7RAEHy5KfxsKOEZtF6XD4n3x38E=",
                       "bundled": true,
                       "dev": true
                     }
@@ -23112,6 +24675,8 @@
                 },
                 "tar-fs": {
                   "version": "1.15.3",
+                  "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.15.3.tgz",
+                  "integrity": "sha1-7M+TXpQUk9gVECjmNuUc5MPKfyA=",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -23123,6 +24688,8 @@
                   "dependencies": {
                     "pump": {
                       "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz",
+                      "integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
                       "bundled": true,
                       "dev": true,
                       "requires": {
@@ -23132,6 +24699,8 @@
                       "dependencies": {
                         "end-of-stream": {
                           "version": "1.4.0",
+                          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
+                          "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
                           "bundled": true,
                           "dev": true,
                           "requires": {
@@ -23144,6 +24713,8 @@
                 },
                 "tar-stream": {
                   "version": "1.5.4",
+                  "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz",
+                  "integrity": "sha1-NlSc8E7RrumyowwBQyUiONr5QBY=",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -23155,6 +24726,8 @@
                   "dependencies": {
                     "bl": {
                       "version": "1.2.1",
+                      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
+                      "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
                       "bundled": true,
                       "dev": true,
                       "requires": {
@@ -23163,6 +24736,8 @@
                     },
                     "end-of-stream": {
                       "version": "1.4.0",
+                      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
+                      "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
                       "bundled": true,
                       "dev": true,
                       "requires": {
@@ -23171,6 +24746,8 @@
                     },
                     "xtend": {
                       "version": "4.0.1",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
                       "bundled": true,
                       "dev": true
                     }
@@ -23180,16 +24757,22 @@
             },
             "path-is-inside": {
               "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+              "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
               "bundled": true,
               "dev": true
             },
             "promise-inflight": {
               "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+              "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
               "bundled": true,
               "dev": true
             },
             "read": {
               "version": "1.0.7",
+              "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+              "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -23198,6 +24781,8 @@
               "dependencies": {
                 "mute-stream": {
                   "version": "0.0.7",
+                  "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+                  "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
                   "bundled": true,
                   "dev": true
                 }
@@ -23205,6 +24790,8 @@
             },
             "read-cmd-shim": {
               "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz",
+              "integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -23213,6 +24800,8 @@
             },
             "read-installed": {
               "version": "4.0.3",
+              "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
+              "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -23227,6 +24816,8 @@
               "dependencies": {
                 "util-extend": {
                   "version": "1.0.3",
+                  "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz",
+                  "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8=",
                   "bundled": true,
                   "dev": true
                 }
@@ -23234,6 +24825,8 @@
             },
             "read-package-json": {
               "version": "2.0.9",
+              "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.9.tgz",
+              "integrity": "sha512-vuV8p921IgyelL4UOKv3FsRuRZSaRn30HanLAOKargsr8TbBEq+I3MgloSRXYuKhNdYP1wlEGilMWAIayA2RFg==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -23245,6 +24838,8 @@
               "dependencies": {
                 "json-parse-helpfulerror": {
                   "version": "1.0.3",
+                  "resolved": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
+                  "integrity": "sha1-E/FM4C7tTpgSl7ZOueO5MuLdE9w=",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -23253,6 +24848,8 @@
                   "dependencies": {
                     "jju": {
                       "version": "1.3.0",
+                      "resolved": "https://registry.npmjs.org/jju/-/jju-1.3.0.tgz",
+                      "integrity": "sha1-2t2e8BkkvHKLA/L3l5vb1i96Kqo=",
                       "bundled": true,
                       "dev": true
                     }
@@ -23262,6 +24859,8 @@
             },
             "read-package-tree": {
               "version": "5.1.6",
+              "resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.1.6.tgz",
+              "integrity": "sha512-FCX1aT3GWyY658wzDICef4p+n0dB+ENRct8E/Qyvppj6xVpOYerBHfUu7OP5Rt1/393Tdglguf5ju5DEX4wZNg==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -23274,6 +24873,8 @@
             },
             "readable-stream": {
               "version": "2.3.2",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.2.tgz",
+              "integrity": "sha1-WgTfBeT1f+Pw3Gj90R3FyXx+b00=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -23288,21 +24889,29 @@
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
                   "bundled": true,
                   "dev": true
                 },
                 "isarray": {
                   "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                  "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
                   "bundled": true,
                   "dev": true
                 },
                 "process-nextick-args": {
                   "version": "1.0.7",
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                  "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
                   "bundled": true,
                   "dev": true
                 },
                 "string_decoder": {
                   "version": "1.0.3",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+                  "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -23311,6 +24920,8 @@
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                  "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
                   "bundled": true,
                   "dev": true
                 }
@@ -23318,6 +24929,8 @@
             },
             "readdir-scoped-modules": {
               "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz",
+              "integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -23329,6 +24942,8 @@
             },
             "request": {
               "version": "2.81.0",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+              "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -23358,21 +24973,29 @@
               "dependencies": {
                 "aws-sign2": {
                   "version": "0.6.0",
+                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+                  "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
                   "bundled": true,
                   "dev": true
                 },
                 "aws4": {
                   "version": "1.6.0",
+                  "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+                  "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
                   "bundled": true,
                   "dev": true
                 },
                 "caseless": {
                   "version": "0.12.0",
+                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+                  "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
                   "bundled": true,
                   "dev": true
                 },
                 "combined-stream": {
                   "version": "1.0.5",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                  "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -23381,6 +25004,8 @@
                   "dependencies": {
                     "delayed-stream": {
                       "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
                       "bundled": true,
                       "dev": true
                     }
@@ -23388,16 +25013,22 @@
                 },
                 "extend": {
                   "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+                  "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
                   "bundled": true,
                   "dev": true
                 },
                 "forever-agent": {
                   "version": "0.6.1",
+                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+                  "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
                   "bundled": true,
                   "dev": true
                 },
                 "form-data": {
                   "version": "2.1.4",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+                  "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -23408,6 +25039,8 @@
                   "dependencies": {
                     "asynckit": {
                       "version": "0.4.0",
+                      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+                      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
                       "bundled": true,
                       "dev": true
                     }
@@ -23415,6 +25048,8 @@
                 },
                 "har-validator": {
                   "version": "4.2.1",
+                  "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+                  "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -23424,6 +25059,8 @@
                   "dependencies": {
                     "ajv": {
                       "version": "4.11.8",
+                      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+                      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
                       "bundled": true,
                       "dev": true,
                       "requires": {
@@ -23433,11 +25070,15 @@
                       "dependencies": {
                         "co": {
                           "version": "4.6.0",
+                          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+                          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
                           "bundled": true,
                           "dev": true
                         },
                         "json-stable-stringify": {
                           "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+                          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
                           "bundled": true,
                           "dev": true,
                           "requires": {
@@ -23446,6 +25087,8 @@
                           "dependencies": {
                             "jsonify": {
                               "version": "0.0.0",
+                              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+                              "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
                               "bundled": true,
                               "dev": true
                             }
@@ -23455,6 +25098,8 @@
                     },
                     "har-schema": {
                       "version": "1.0.5",
+                      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+                      "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
                       "bundled": true,
                       "dev": true
                     }
@@ -23462,6 +25107,8 @@
                 },
                 "hawk": {
                   "version": "3.1.3",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+                  "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -23473,6 +25120,8 @@
                   "dependencies": {
                     "boom": {
                       "version": "2.10.1",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
                       "bundled": true,
                       "dev": true,
                       "requires": {
@@ -23481,6 +25130,8 @@
                     },
                     "cryptiles": {
                       "version": "2.0.5",
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
                       "bundled": true,
                       "dev": true,
                       "requires": {
@@ -23489,11 +25140,15 @@
                     },
                     "hoek": {
                       "version": "2.16.3",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
                       "bundled": true,
                       "dev": true
                     },
                     "sntp": {
                       "version": "1.0.9",
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
                       "bundled": true,
                       "dev": true,
                       "requires": {
@@ -23504,6 +25159,8 @@
                 },
                 "http-signature": {
                   "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+                  "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -23514,11 +25171,15 @@
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.2.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+                      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
                       "bundled": true,
                       "dev": true
                     },
                     "jsprim": {
                       "version": "1.4.0",
+                      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+                      "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
                       "bundled": true,
                       "dev": true,
                       "requires": {
@@ -23530,21 +25191,29 @@
                       "dependencies": {
                         "assert-plus": {
                           "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
                           "bundled": true,
                           "dev": true
                         },
                         "extsprintf": {
                           "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+                          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
                           "bundled": true,
                           "dev": true
                         },
                         "json-schema": {
                           "version": "0.2.3",
+                          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+                          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
                           "bundled": true,
                           "dev": true
                         },
                         "verror": {
                           "version": "1.3.6",
+                          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+                          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
                           "bundled": true,
                           "dev": true,
                           "requires": {
@@ -23555,6 +25224,8 @@
                     },
                     "sshpk": {
                       "version": "1.13.1",
+                      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+                      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
                       "bundled": true,
                       "dev": true,
                       "requires": {
@@ -23570,16 +25241,22 @@
                       "dependencies": {
                         "asn1": {
                           "version": "0.2.3",
+                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+                          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
                           "bundled": true,
                           "dev": true
                         },
                         "assert-plus": {
                           "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
                           "bundled": true,
                           "dev": true
                         },
                         "bcrypt-pbkdf": {
                           "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+                          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
                           "bundled": true,
                           "dev": true,
                           "optional": true,
@@ -23589,6 +25266,8 @@
                         },
                         "dashdash": {
                           "version": "1.14.1",
+                          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+                          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
                           "bundled": true,
                           "dev": true,
                           "requires": {
@@ -23597,6 +25276,8 @@
                         },
                         "ecc-jsbn": {
                           "version": "0.1.1",
+                          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
                           "bundled": true,
                           "dev": true,
                           "optional": true,
@@ -23606,6 +25287,8 @@
                         },
                         "getpass": {
                           "version": "0.1.7",
+                          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+                          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
                           "bundled": true,
                           "dev": true,
                           "requires": {
@@ -23614,12 +25297,16 @@
                         },
                         "jsbn": {
                           "version": "0.1.1",
+                          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+                          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
                           "bundled": true,
                           "dev": true,
                           "optional": true
                         },
                         "tweetnacl": {
                           "version": "0.14.5",
+                          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+                          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
                           "bundled": true,
                           "dev": true,
                           "optional": true
@@ -23630,21 +25317,29 @@
                 },
                 "is-typedarray": {
                   "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+                  "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
                   "bundled": true,
                   "dev": true
                 },
                 "isstream": {
                   "version": "0.1.2",
+                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+                  "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
                   "bundled": true,
                   "dev": true
                 },
                 "json-stringify-safe": {
                   "version": "5.0.1",
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+                  "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
                   "bundled": true,
                   "dev": true
                 },
                 "mime-types": {
                   "version": "2.1.15",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+                  "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -23653,6 +25348,8 @@
                   "dependencies": {
                     "mime-db": {
                       "version": "1.27.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+                      "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
                       "bundled": true,
                       "dev": true
                     }
@@ -23660,26 +25357,36 @@
                 },
                 "oauth-sign": {
                   "version": "0.8.2",
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+                  "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
                   "bundled": true,
                   "dev": true
                 },
                 "performance-now": {
                   "version": "0.2.0",
+                  "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+                  "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
                   "bundled": true,
                   "dev": true
                 },
                 "qs": {
                   "version": "6.4.0",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+                  "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
                   "bundled": true,
                   "dev": true
                 },
                 "stringstream": {
                   "version": "0.0.5",
+                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+                  "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
                   "bundled": true,
                   "dev": true
                 },
                 "tough-cookie": {
                   "version": "2.3.2",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+                  "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -23688,6 +25395,8 @@
                   "dependencies": {
                     "punycode": {
                       "version": "1.4.1",
+                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+                      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
                       "bundled": true,
                       "dev": true
                     }
@@ -23695,6 +25404,8 @@
                 },
                 "tunnel-agent": {
                   "version": "0.6.0",
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+                  "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -23705,11 +25416,15 @@
             },
             "retry": {
               "version": "0.10.1",
+              "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
+              "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
               "bundled": true,
               "dev": true
             },
             "rimraf": {
               "version": "2.6.1",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+              "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -23718,16 +25433,22 @@
             },
             "safe-buffer": {
               "version": "5.1.1",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+              "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
               "bundled": true,
               "dev": true
             },
             "semver": {
               "version": "5.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+              "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
               "bundled": true,
               "dev": true
             },
             "sha": {
               "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/sha/-/sha-2.0.1.tgz",
+              "integrity": "sha1-YDCCL70smCOUn49y7WQR7lzyWq4=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -23737,16 +25458,22 @@
             },
             "slide": {
               "version": "1.1.6",
+              "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+              "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
               "bundled": true,
               "dev": true
             },
             "sorted-object": {
               "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/sorted-object/-/sorted-object-2.0.1.tgz",
+              "integrity": "sha1-fWMfS9OnmKJK8d/8+/6DM3pd9fw=",
               "bundled": true,
               "dev": true
             },
             "sorted-union-stream": {
               "version": "2.1.3",
+              "resolved": "https://registry.npmjs.org/sorted-union-stream/-/sorted-union-stream-2.1.3.tgz",
+              "integrity": "sha1-x3lMfgd4gAUv9xqNSi27Sppjisc=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -23756,6 +25483,8 @@
               "dependencies": {
                 "from2": {
                   "version": "1.3.0",
+                  "resolved": "https://registry.npmjs.org/from2/-/from2-1.3.0.tgz",
+                  "integrity": "sha1-iEE7qqX5pZfP3pIh2GmGzTwGHf0=",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -23765,6 +25494,8 @@
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.1.14",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                       "bundled": true,
                       "dev": true,
                       "requires": {
@@ -23776,16 +25507,22 @@
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
                           "bundled": true,
                           "dev": true
                         },
                         "isarray": {
                           "version": "0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
                           "bundled": true,
                           "dev": true
                         },
                         "string_decoder": {
                           "version": "0.10.31",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
                           "bundled": true,
                           "dev": true
                         }
@@ -23795,6 +25532,8 @@
                 },
                 "stream-iterate": {
                   "version": "1.2.0",
+                  "resolved": "https://registry.npmjs.org/stream-iterate/-/stream-iterate-1.2.0.tgz",
+                  "integrity": "sha1-K9fHcpbBcCpGSIuK1B95hl7s1OE=",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -23804,6 +25543,8 @@
                   "dependencies": {
                     "stream-shift": {
                       "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+                      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
                       "bundled": true,
                       "dev": true
                     }
@@ -23813,6 +25554,8 @@
             },
             "ssri": {
               "version": "4.1.6",
+              "resolved": "https://registry.npmjs.org/ssri/-/ssri-4.1.6.tgz",
+              "integrity": "sha512-WUbCdgSAMQjTFZRWvSPpauryvREEA+Krn19rx67UlJEJx/M192ZHxMmJXjZ4tkdFm+Sb0SXGlENeQVlA5wY7kA==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -23821,6 +25564,8 @@
             },
             "strip-ansi": {
               "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -23829,6 +25574,8 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                  "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
                   "bundled": true,
                   "dev": true
                 }
@@ -23836,6 +25583,8 @@
             },
             "tar": {
               "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+              "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -23846,6 +25595,8 @@
               "dependencies": {
                 "block-stream": {
                   "version": "0.0.9",
+                  "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+                  "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -23856,21 +25607,29 @@
             },
             "text-table": {
               "version": "0.2.0",
+              "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+              "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
               "bundled": true,
               "dev": true
             },
             "uid-number": {
               "version": "0.0.6",
+              "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+              "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
               "bundled": true,
               "dev": true
             },
             "umask": {
               "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
+              "integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
               "bundled": true,
               "dev": true
             },
             "unique-filename": {
               "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
+              "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -23879,6 +25638,8 @@
               "dependencies": {
                 "unique-slug": {
                   "version": "2.0.0",
+                  "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
+                  "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -23889,11 +25650,15 @@
             },
             "unpipe": {
               "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+              "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
               "bundled": true,
               "dev": true
             },
             "update-notifier": {
               "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.2.0.tgz",
+              "integrity": "sha1-G1g3z5DAc22IYncytmHBOPht5y8=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -23909,6 +25674,8 @@
               "dependencies": {
                 "boxen": {
                   "version": "1.1.0",
+                  "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.1.0.tgz",
+                  "integrity": "sha1-sbad1SIwXoB6md7ud329blFnsQI=",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -23923,6 +25690,8 @@
                   "dependencies": {
                     "ansi-align": {
                       "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
+                      "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
                       "bundled": true,
                       "dev": true,
                       "requires": {
@@ -23931,16 +25700,22 @@
                     },
                     "camelcase": {
                       "version": "4.1.0",
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+                      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
                       "bundled": true,
                       "dev": true
                     },
                     "cli-boxes": {
                       "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+                      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
                       "bundled": true,
                       "dev": true
                     },
                     "string-width": {
                       "version": "2.1.0",
+                      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.0.tgz",
+                      "integrity": "sha1-AwZkVh/BRslCPsfZeP4kV0N/5tA=",
                       "bundled": true,
                       "dev": true,
                       "requires": {
@@ -23950,11 +25725,15 @@
                       "dependencies": {
                         "is-fullwidth-code-point": {
                           "version": "2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
                           "bundled": true,
                           "dev": true
                         },
                         "strip-ansi": {
                           "version": "4.0.0",
+                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                           "bundled": true,
                           "dev": true,
                           "requires": {
@@ -23965,6 +25744,8 @@
                     },
                     "term-size": {
                       "version": "0.1.1",
+                      "resolved": "https://registry.npmjs.org/term-size/-/term-size-0.1.1.tgz",
+                      "integrity": "sha1-hzYLljlsq1dgljcUzaDQy+7K2co=",
                       "bundled": true,
                       "dev": true,
                       "requires": {
@@ -23973,6 +25754,8 @@
                       "dependencies": {
                         "execa": {
                           "version": "0.4.0",
+                          "resolved": "https://registry.npmjs.org/execa/-/execa-0.4.0.tgz",
+                          "integrity": "sha1-TrZGejaglfq7KXD/nV4/t7zm68M=",
                           "bundled": true,
                           "dev": true,
                           "requires": {
@@ -23986,6 +25769,8 @@
                           "dependencies": {
                             "cross-spawn-async": {
                               "version": "2.2.5",
+                              "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz",
+                              "integrity": "sha1-hF/wwINKPe2dFg2sptOQkGuyiMw=",
                               "bundled": true,
                               "dev": true,
                               "requires": {
@@ -23995,11 +25780,15 @@
                             },
                             "is-stream": {
                               "version": "1.1.0",
+                              "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+                              "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
                               "bundled": true,
                               "dev": true
                             },
                             "npm-run-path": {
                               "version": "1.0.0",
+                              "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
+                              "integrity": "sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8=",
                               "bundled": true,
                               "dev": true,
                               "requires": {
@@ -24008,16 +25797,22 @@
                             },
                             "object-assign": {
                               "version": "4.1.1",
+                              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+                              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
                               "bundled": true,
                               "dev": true
                             },
                             "path-key": {
                               "version": "1.0.0",
+                              "resolved": "https://registry.npmjs.org/path-key/-/path-key-1.0.0.tgz",
+                              "integrity": "sha1-XVPVeAGWRsDWiADbThRua9wqx68=",
                               "bundled": true,
                               "dev": true
                             },
                             "strip-eof": {
                               "version": "1.0.0",
+                              "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+                              "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
                               "bundled": true,
                               "dev": true
                             }
@@ -24027,6 +25822,8 @@
                     },
                     "widest-line": {
                       "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
+                      "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
                       "bundled": true,
                       "dev": true,
                       "requires": {
@@ -24035,6 +25832,8 @@
                       "dependencies": {
                         "string-width": {
                           "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                           "bundled": true,
                           "dev": true,
                           "requires": {
@@ -24045,11 +25844,15 @@
                           "dependencies": {
                             "code-point-at": {
                               "version": "1.1.0",
+                              "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+                              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
                               "bundled": true,
                               "dev": true
                             },
                             "is-fullwidth-code-point": {
                               "version": "1.0.0",
+                              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                               "bundled": true,
                               "dev": true,
                               "requires": {
@@ -24058,6 +25861,8 @@
                               "dependencies": {
                                 "number-is-nan": {
                                   "version": "1.0.1",
+                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                                  "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
                                   "bundled": true,
                                   "dev": true
                                 }
@@ -24065,6 +25870,8 @@
                             },
                             "strip-ansi": {
                               "version": "3.0.1",
+                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                               "bundled": true,
                               "dev": true,
                               "requires": {
@@ -24073,6 +25880,8 @@
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.1.1",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                                  "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                                   "bundled": true,
                                   "dev": true
                                 }
@@ -24086,6 +25895,8 @@
                 },
                 "chalk": {
                   "version": "1.1.3",
+                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                  "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -24098,16 +25909,22 @@
                   "dependencies": {
                     "ansi-styles": {
                       "version": "2.2.1",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
                       "bundled": true,
                       "dev": true
                     },
                     "escape-string-regexp": {
                       "version": "1.0.5",
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
                       "bundled": true,
                       "dev": true
                     },
                     "has-ansi": {
                       "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
                       "bundled": true,
                       "dev": true,
                       "requires": {
@@ -24116,6 +25933,8 @@
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.1.1",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                           "bundled": true,
                           "dev": true
                         }
@@ -24123,6 +25942,8 @@
                     },
                     "strip-ansi": {
                       "version": "3.0.1",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                       "bundled": true,
                       "dev": true,
                       "requires": {
@@ -24131,6 +25952,8 @@
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.1.1",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                           "bundled": true,
                           "dev": true
                         }
@@ -24138,6 +25961,8 @@
                     },
                     "supports-color": {
                       "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
                       "bundled": true,
                       "dev": true
                     }
@@ -24145,6 +25970,8 @@
                 },
                 "configstore": {
                   "version": "3.1.0",
+                  "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.0.tgz",
+                  "integrity": "sha1-Rd+QcHPibfoc9LLVL1tgVF6qEdE=",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -24158,6 +25985,8 @@
                   "dependencies": {
                     "dot-prop": {
                       "version": "4.1.1",
+                      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.1.1.tgz",
+                      "integrity": "sha1-qEk/C3te7sglJbXHWH+n3nyoWcE=",
                       "bundled": true,
                       "dev": true,
                       "requires": {
@@ -24166,6 +25995,8 @@
                       "dependencies": {
                         "is-obj": {
                           "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+                          "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
                           "bundled": true,
                           "dev": true
                         }
@@ -24173,6 +26004,8 @@
                     },
                     "make-dir": {
                       "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.0.0.tgz",
+                      "integrity": "sha1-l6ARdR6R3YfPre9Ygy67BJNt6Xg=",
                       "bundled": true,
                       "dev": true,
                       "requires": {
@@ -24181,6 +26014,8 @@
                       "dependencies": {
                         "pify": {
                           "version": "2.3.0",
+                          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
                           "bundled": true,
                           "dev": true
                         }
@@ -24188,6 +26023,8 @@
                     },
                     "unique-string": {
                       "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+                      "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
                       "bundled": true,
                       "dev": true,
                       "requires": {
@@ -24196,6 +26033,8 @@
                       "dependencies": {
                         "crypto-random-string": {
                           "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+                          "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
                           "bundled": true,
                           "dev": true
                         }
@@ -24205,16 +26044,22 @@
                 },
                 "import-lazy": {
                   "version": "2.1.0",
+                  "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+                  "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
                   "bundled": true,
                   "dev": true
                 },
                 "is-npm": {
                   "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+                  "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
                   "bundled": true,
                   "dev": true
                 },
                 "latest-version": {
                   "version": "3.1.0",
+                  "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
+                  "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -24223,6 +26068,8 @@
                   "dependencies": {
                     "package-json": {
                       "version": "4.0.1",
+                      "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
+                      "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
                       "bundled": true,
                       "dev": true,
                       "requires": {
@@ -24234,6 +26081,8 @@
                       "dependencies": {
                         "got": {
                           "version": "6.7.1",
+                          "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+                          "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
                           "bundled": true,
                           "dev": true,
                           "requires": {
@@ -24252,6 +26101,8 @@
                           "dependencies": {
                             "create-error-class": {
                               "version": "3.0.2",
+                              "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+                              "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
                               "bundled": true,
                               "dev": true,
                               "requires": {
@@ -24260,6 +26111,8 @@
                               "dependencies": {
                                 "capture-stack-trace": {
                                   "version": "1.0.0",
+                                  "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
+                                  "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
                                   "bundled": true,
                                   "dev": true
                                 }
@@ -24267,46 +26120,64 @@
                             },
                             "duplexer3": {
                               "version": "0.1.4",
+                              "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+                              "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
                               "bundled": true,
                               "dev": true
                             },
                             "get-stream": {
                               "version": "3.0.0",
+                              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+                              "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
                               "bundled": true,
                               "dev": true
                             },
                             "is-redirect": {
                               "version": "1.0.0",
+                              "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+                              "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
                               "bundled": true,
                               "dev": true
                             },
                             "is-retry-allowed": {
                               "version": "1.1.0",
+                              "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+                              "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
                               "bundled": true,
                               "dev": true
                             },
                             "is-stream": {
                               "version": "1.1.0",
+                              "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+                              "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
                               "bundled": true,
                               "dev": true
                             },
                             "lowercase-keys": {
                               "version": "1.0.0",
+                              "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+                              "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
                               "bundled": true,
                               "dev": true
                             },
                             "timed-out": {
                               "version": "4.0.1",
+                              "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+                              "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
                               "bundled": true,
                               "dev": true
                             },
                             "unzip-response": {
                               "version": "2.0.1",
+                              "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
+                              "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
                               "bundled": true,
                               "dev": true
                             },
                             "url-parse-lax": {
                               "version": "1.0.0",
+                              "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+                              "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
                               "bundled": true,
                               "dev": true,
                               "requires": {
@@ -24315,6 +26186,8 @@
                               "dependencies": {
                                 "prepend-http": {
                                   "version": "1.0.4",
+                                  "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+                                  "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
                                   "bundled": true,
                                   "dev": true
                                 }
@@ -24324,6 +26197,8 @@
                         },
                         "registry-auth-token": {
                           "version": "3.3.1",
+                          "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz",
+                          "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
                           "bundled": true,
                           "dev": true,
                           "requires": {
@@ -24333,6 +26208,8 @@
                           "dependencies": {
                             "rc": {
                               "version": "1.2.1",
+                              "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+                              "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
                               "bundled": true,
                               "dev": true,
                               "requires": {
@@ -24344,16 +26221,22 @@
                               "dependencies": {
                                 "deep-extend": {
                                   "version": "0.4.2",
+                                  "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+                                  "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
                                   "bundled": true,
                                   "dev": true
                                 },
                                 "minimist": {
                                   "version": "1.2.0",
+                                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                                  "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                                   "bundled": true,
                                   "dev": true
                                 },
                                 "strip-json-comments": {
                                   "version": "2.0.1",
+                                  "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+                                  "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
                                   "bundled": true,
                                   "dev": true
                                 }
@@ -24363,6 +26246,8 @@
                         },
                         "registry-url": {
                           "version": "3.1.0",
+                          "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+                          "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
                           "bundled": true,
                           "dev": true,
                           "requires": {
@@ -24371,6 +26256,8 @@
                           "dependencies": {
                             "rc": {
                               "version": "1.2.1",
+                              "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+                              "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
                               "bundled": true,
                               "dev": true,
                               "requires": {
@@ -24382,16 +26269,22 @@
                               "dependencies": {
                                 "deep-extend": {
                                   "version": "0.4.2",
+                                  "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+                                  "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
                                   "bundled": true,
                                   "dev": true
                                 },
                                 "minimist": {
                                   "version": "1.2.0",
+                                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                                  "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                                   "bundled": true,
                                   "dev": true
                                 },
                                 "strip-json-comments": {
                                   "version": "2.0.1",
+                                  "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+                                  "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
                                   "bundled": true,
                                   "dev": true
                                 }
@@ -24405,6 +26298,8 @@
                 },
                 "semver-diff": {
                   "version": "2.1.0",
+                  "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+                  "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -24413,6 +26308,8 @@
                 },
                 "xdg-basedir": {
                   "version": "3.0.0",
+                  "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+                  "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
                   "bundled": true,
                   "dev": true
                 }
@@ -24420,11 +26317,15 @@
             },
             "uuid": {
               "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+              "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
               "bundled": true,
               "dev": true
             },
             "validate-npm-package-license": {
               "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+              "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -24434,6 +26335,8 @@
               "dependencies": {
                 "spdx-correct": {
                   "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+                  "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -24442,6 +26345,8 @@
                   "dependencies": {
                     "spdx-license-ids": {
                       "version": "1.2.2",
+                      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+                      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
                       "bundled": true,
                       "dev": true
                     }
@@ -24449,6 +26354,8 @@
                 },
                 "spdx-expression-parse": {
                   "version": "1.0.4",
+                  "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+                  "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
                   "bundled": true,
                   "dev": true
                 }
@@ -24456,6 +26363,8 @@
             },
             "validate-npm-package-name": {
               "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+              "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -24464,6 +26373,8 @@
               "dependencies": {
                 "builtins": {
                   "version": "1.0.3",
+                  "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
+                  "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
                   "bundled": true,
                   "dev": true
                 }
@@ -24471,6 +26382,8 @@
             },
             "which": {
               "version": "1.2.14",
+              "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+              "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -24479,6 +26392,8 @@
               "dependencies": {
                 "isexe": {
                   "version": "2.0.0",
+                  "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+                  "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
                   "bundled": true,
                   "dev": true
                 }
@@ -24486,6 +26401,8 @@
             },
             "worker-farm": {
               "version": "1.3.1",
+              "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.3.1.tgz",
+              "integrity": "sha1-QzMRK7SbF6oFC4eJXKayys9A5f8=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -24495,6 +26412,8 @@
               "dependencies": {
                 "errno": {
                   "version": "0.1.4",
+                  "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
+                  "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -24503,6 +26422,8 @@
                   "dependencies": {
                     "prr": {
                       "version": "0.0.0",
+                      "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
+                      "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=",
                       "bundled": true,
                       "dev": true
                     }
@@ -24510,6 +26431,8 @@
                 },
                 "xtend": {
                   "version": "4.0.1",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                  "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
                   "bundled": true,
                   "dev": true
                 }
@@ -24517,11 +26440,15 @@
             },
             "wrappy": {
               "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
               "bundled": true,
               "dev": true
             },
             "write-file-atomic": {
               "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.1.0.tgz",
+              "integrity": "sha512-0TZ20a+xcIl4u0+Mj5xDH2yOWdmQiXlKf9Hm+TgDXjTMsEYb+gDrmb8e8UNAzMCitX8NBqG4Z/FUQIyzv/R1JQ==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -24534,6 +26461,8 @@
         },
         "npm-package-arg": {
           "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.1.1.tgz",
+          "integrity": "sha512-qBpssaL3IOZWi5vEKUKW0cO7kzLeT+EQO9W8RsLOZf76KF9E/K9+wH0C7t06HXPpaH8WH5xF1MExLuCwbTqRUg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -24545,6 +26474,8 @@
         },
         "npm-run-path": {
           "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -24553,11 +26484,15 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "bundled": true,
           "dev": true
         },
         "once": {
           "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -24566,11 +26501,15 @@
         },
         "os-homedir": {
           "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "bundled": true,
           "dev": true
         },
         "os-locale": {
           "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+          "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -24581,6 +26520,8 @@
           "dependencies": {
             "cross-spawn": {
               "version": "6.0.5",
+              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+              "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -24593,6 +26534,8 @@
             },
             "execa": {
               "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+              "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -24607,6 +26550,8 @@
             },
             "get-stream": {
               "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+              "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -24617,11 +26562,15 @@
         },
         "os-tmpdir": {
           "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "bundled": true,
           "dev": true
         },
         "osenv": {
           "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -24631,21 +26580,29 @@
         },
         "p-defer": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+          "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
           "bundled": true,
           "dev": true
         },
         "p-finally": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
           "bundled": true,
           "dev": true
         },
         "p-is-promise": {
           "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
+          "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
           "bundled": true,
           "dev": true
         },
         "p-limit": {
           "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -24654,6 +26611,8 @@
         },
         "p-locate": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -24662,11 +26621,15 @@
         },
         "p-try": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
           "bundled": true,
           "dev": true
         },
         "package-json": {
           "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
+          "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -24678,41 +26641,57 @@
         },
         "path-exists": {
           "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "bundled": true,
           "dev": true
         },
         "path-is-absolute": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "bundled": true,
           "dev": true
         },
         "path-is-inside": {
           "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+          "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
           "bundled": true,
           "dev": true
         },
         "path-key": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
           "bundled": true,
           "dev": true
         },
         "pify": {
           "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "bundled": true,
           "dev": true
         },
         "prepend-http": {
           "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
           "bundled": true,
           "dev": true
         },
         "pseudomap": {
           "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
           "bundled": true,
           "dev": true
         },
         "pump": {
           "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -24722,6 +26701,8 @@
         },
         "rc": {
           "version": "1.2.8",
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -24733,6 +26714,8 @@
         },
         "registry-auth-token": {
           "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
+          "integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -24742,6 +26725,8 @@
         },
         "registry-url": {
           "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+          "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -24750,16 +26735,22 @@
         },
         "require-directory": {
           "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
           "bundled": true,
           "dev": true
         },
         "require-main-filename": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
           "bundled": true,
           "dev": true
         },
         "rimraf": {
           "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -24768,16 +26759,22 @@
         },
         "safe-buffer": {
           "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
           "bundled": true,
           "dev": true
         },
         "semver": {
           "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "bundled": true,
           "dev": true
         },
         "semver-diff": {
           "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+          "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -24786,11 +26783,15 @@
         },
         "set-blocking": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "bundled": true,
           "dev": true
         },
         "shebang-command": {
           "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -24799,16 +26800,22 @@
         },
         "shebang-regex": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
           "bundled": true,
           "dev": true
         },
         "signal-exit": {
           "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "bundled": true,
           "dev": true
         },
         "string-width": {
           "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -24818,6 +26825,8 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -24826,16 +26835,22 @@
         },
         "strip-eof": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
           "bundled": true,
           "dev": true
         },
         "strip-json-comments": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "bundled": true,
           "dev": true
         },
         "supports-color": {
           "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -24844,6 +26859,8 @@
         },
         "term-size": {
           "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
+          "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -24852,11 +26869,15 @@
         },
         "timed-out": {
           "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+          "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
           "bundled": true,
           "dev": true
         },
         "unique-string": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+          "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -24865,11 +26886,15 @@
         },
         "unzip-response": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
+          "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
           "bundled": true,
           "dev": true
         },
         "update-notifier": {
           "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
+          "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -24887,6 +26912,8 @@
         },
         "url-parse-lax": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -24895,6 +26922,8 @@
         },
         "validate-npm-package-name": {
           "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+          "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -24903,6 +26932,8 @@
         },
         "which": {
           "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -24911,11 +26942,15 @@
         },
         "which-module": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
           "bundled": true,
           "dev": true
         },
         "widest-line": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
+          "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -24924,6 +26959,8 @@
         },
         "wrap-ansi": {
           "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -24933,11 +26970,15 @@
           "dependencies": {
             "ansi-regex": {
               "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
               "bundled": true,
               "dev": true
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -24946,6 +26987,8 @@
             },
             "string-width": {
               "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -24956,6 +26999,8 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -24966,11 +27011,15 @@
         },
         "wrappy": {
           "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "bundled": true,
           "dev": true
         },
         "write-file-atomic": {
           "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+          "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -24981,21 +27030,29 @@
         },
         "xdg-basedir": {
           "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+          "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
           "bundled": true,
           "dev": true
         },
         "y18n": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
           "bundled": true,
           "dev": true
         },
         "yallist": {
           "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
           "bundled": true,
           "dev": true
         },
         "yargs": {
           "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.1.tgz",
+          "integrity": "sha512-PRU7gJrJaXv3q3yQZ/+/X6KBswZiaQ+zOmdprZcouPYtQgvNU35i+68M4b1ZHLZtYFT5QObFLV+ZkmJYcwKdiw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -25015,6 +27072,8 @@
           "dependencies": {
             "y18n": {
               "version": "3.2.1",
+              "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+              "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
               "bundled": true,
               "dev": true
             }
@@ -25022,6 +27081,8 @@
         },
         "yargs-parser": {
           "version": "9.0.2",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
+          "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
           "bundled": true,
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "chalk": "^4.1.2",
     "clear": "^0.1.0",
     "cli-autoupdate": "^2.0.4",
+    "clipboardy": "^3.0.0",
     "clui": "^0.3.6",
     "configstore": "^6.0.0",
     "figlet": "^1.5.2",


### PR DESCRIPTION
Uses clipboardy instead of `pbclip` and others for cross platform clipboard access. On my OS (Manjaro), the recommended clipboard management command was `xclip` and `xsel` but neither came pre-installed. It seems to make sense to avoid any issues  around installed packages and instead use `clipboardy` which has already worked out the quirks. For example, on linux, it uses `xsel` internally and includes a local fallback binary for it.

The `package-lock` diff seems to come from `npm i` on a more recent version of npm. Let me know if I should downgrade and to what version. Or if it's fine to update the `package-lock`.