### PR TITLE
Don't re-init plugin when already initted

### DIFF
--- a/includes/base.js
+++ b/includes/base.js
@@ -44,6 +44,9 @@ class PluginBase {
    * Action to run upon initialization
    */
   init() {
+    // Already initted
+    if (this.$el) return
+
     // Next Theme
     const $toolbarBtn = document.createElement('button');
     this.$el = $toolbarBtn;


### PR DESCRIPTION
Avoids a bug where the plugins will create more than one button in the toolbar. Closes #122