### PR TITLE
Catppuccin Theme

### DIFF
--- a/includes/themes.js
+++ b/includes/themes.js
@@ -33,6 +33,7 @@ class NextThemePlugin extends window.slackPluginsAPI.pluginBase {
       'nightowl',
       'lightowl',
       'moonlight',
+      'catppuccin',
       'default',
     ];
     // Current theme

--- a/lib/themes.yml
+++ b/lib/themes.yml
@@ -787,23 +787,23 @@ other:
     className: catppuccin
     desc: Pastel theme based on Catppuccin colors
     dark: true
-    background: '#1E1E2E' # Changes main area
+    background: '#1E1E2E'
     foreground: '#D9E0EE'
     text: '#D9E0EE'
-    selectBg: '#302D41' # Not sure
+    selectBg: '#302D41'
     selectFg: '#FFFFFF'
     selectFg2: '#FFFFFF'
     button: '#302D41'
-    second: '#1E1E2E' # Changes headers and selection
+    second: '#1E1E2E'
     disabled: '#6E6C7E'
-    contrast: '#1E1E2E' # Changes sidebar and others
-    table: '#1E1E2E' # This is the actual border
-    border: '#302D41' # Doesnt change the border?
-    hl: '#575268'
+    contrast: '#1E1E2E'
+    table: '#1E1E2E'
+    border: '#302D41'
+    hl: '#302D41'
     tree: '#57526870'
     notif: '#161320'
     accent: '#96CDFB'
-    excluded: '#302D41' # Hover over message background
+    excluded: '#302D41'
     green: '#7af8ca'
     red: '#F28FAD'
     yellow: '#FAE3B0'
@@ -822,6 +822,6 @@ other:
     tags: '#ff757f'
     strings: '#ABE9B3'
     operators: '#FAE3B0'
-    attributes: '#96CDFB' # This is the primary for some reason
+    attributes: '#96CDFB'
     numbers: '#F8BD96'
     parameters: '#F5C2E7'

--- a/lib/themes.yml
+++ b/lib/themes.yml
@@ -780,3 +780,48 @@ other:
     attributes: '#ffbd76'
     numbers: '#ff9668'
     parameters: '#f3c1ff'
+
+  - catppuccin:
+    name: Catppuccin
+    name2: Catppuccin
+    className: catppuccin
+    desc: Pastel theme based on Catppuccin colors
+    dark: true
+    background: '#1E1E2E' # Changes main area
+    foreground: '#D9E0EE'
+    text: '#D9E0EE'
+    selectBg: '#302D41' # Not sure
+    selectFg: '#FFFFFF'
+    selectFg2: '#FFFFFF'
+    button: '#302D41'
+    second: '#1E1E2E' # Changes headers and selection
+    disabled: '#6E6C7E'
+    contrast: '#1E1E2E' # Changes sidebar and others
+    table: '#1E1E2E' # This is the actual border
+    border: '#302D41' # Doesnt change the border?
+    hl: '#575268'
+    tree: '#57526870'
+    notif: '#161320'
+    accent: '#96CDFB'
+    excluded: '#302D41' # Hover over message background
+    green: '#7af8ca'
+    red: '#F28FAD'
+    yellow: '#FAE3B0'
+    blue: '#96CDFB'
+    purple: '#DDB6F2'
+    orange: '#F8BD96'
+    cyan: '#B5E8E0'
+    white: '#D9E0EE'
+    gray: '#7e8eda'
+    error: '#ff5370'
+    comments: '#7e8eda'
+    vars: '#c8d3f5'
+    links: '#96CDFB'
+    functions: '#96CDFB'
+    keywords: '#FAE3B0'
+    tags: '#ff757f'
+    strings: '#ABE9B3'
+    operators: '#FAE3B0'
+    attributes: '#96CDFB' # This is the primary for some reason
+    numbers: '#F8BD96'
+    parameters: '#F5C2E7'

--- a/styles/app/_video_controls.scss
+++ b/styles/app/_video_controls.scss
@@ -20,7 +20,7 @@
 
 .p-video_controls_overlay--controls {
   &:before {
-    background: linear-gradient(180deg, transparent, $text 70%);
+    background: linear-gradient(180deg, transparent, #000a 70%);
   }
 }
 

--- a/styles/app/_video_controls.scss
+++ b/styles/app/_video_controls.scss
@@ -15,7 +15,7 @@
 }
 
 .p-video_controls_overlay {
-  color: $bg;
+  color: $fg;
 }
 
 .p-video_controls_overlay--controls {

--- a/styles/app/_wysiwig.scss
+++ b/styles/app/_wysiwig.scss
@@ -90,7 +90,7 @@ button:focus > .p-wysiwyg_deluxe_toast__close {
   }
 
   &.c-wysiwyg_container__button--send_options.c-wysiwyg_container__button--disabled {
-    background: $contrast !important;
+    background: transparent !important;
   }
 
   &.c-wysiwyg_container__button--send.c-wysiwyg_container__button--experiment_draft_scheduling {
@@ -254,7 +254,7 @@ button:focus > .p-wysiwyg_deluxe_toast__close {
 }
 
 .c-wysiwyg_container--theme_dark {
-  background-color: $contrast;
+  background-color: $button;
   border-color: $borderLight;
 
   code {


### PR DESCRIPTION
Adds my personal Catppuccin theme to the repo based on https://github.com/catppuccin/catppuccin. Unfortunately I don't have a slack workspace that I can share a screenshot of publicly. The theme loosely follows the catppuccin guidelines and deviates in that it takes a flat approach to the background colors. The sidebar, headers, and base backgrounds are all the same with only buttons, code blocks, etc having a brighter background color. The PR also makes some slight changes to the styling based off issues I had while building the theme. 

Feel free to close if themes of this style don't make sense in-repo