### PR TITLE
Enable apply for Windows and Linux

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,7 +1,9 @@
 const inquirer = require('inquirer');
 const chalk = require('chalk');
+const os = require('os');
 
 const { getDefaultLocation } = require('./dirs');
+const { getIsMac } = require('./utils');
 
 exports.askLocation = () =>
   inquirer.prompt([
@@ -24,7 +26,13 @@ exports.ask = () =>
       type: 'list',
       name: 'ask',
       choices: [
-        { name: 'Run Slack in Dev Mode and copy custom code to clipboard (Mac)', value: 'mac' },
+        // Use clipboard workaround for Mac, otherwise apply
+        ...(getIsMac()
+          ? [{ name: 'Run Slack in Dev Mode and copy custom code to clipboard (Mac)', value: 'mac' }]
+          : [
+              { name: 'Apply tweaks', value: 'apply' },
+              { name: 'Restore Slack', value: 'remove' },
+            ]),
         { name: 'Display mtslack Version', value: 'version' },
         { name: 'Exit', value: 'exit' },
       ],

--- a/lib/dirs.js
+++ b/lib/dirs.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const os = require('os');
-const osType = os.type();
+const { getIsLinux, getIsMac, getIsWindows } = require('./utils');
 const homeDir = os.homedir();
 
 const getLinuxAppDir = () => {
@@ -73,22 +73,16 @@ const getMacAppDir = () => {
   }
 
   throw `Mac: Could not find Slack app in the following locations:
-  ⚡️ ${userDir} 
+  ⚡️ ${userDir}
   ⚡️ ${dir}
 `;
 };
 
 exports.getDefaultLocation = () => {
-  switch (osType) {
-    case 'Linux':
-      return `/usr/lib/slack`;
-    case 'Windows_NT':
-      return `${homeDir}\\AppData\\Local\\slack\\app-xxx`;
-    case 'Darwin':
-      return `/Applications/Slack.app`;
-    default:
-      throw 'Unsupported operating system';
-  }
+  if (getIsLinux()) return `/usr/lib/slack`;
+  if (getIsMac()) return `/Applications/Slack.app`;
+  if (getIsWindows()) return `${homeDir}\\AppData\\Local\\slack\\app-xxx`;
+  throw Error('Unsupported operating system');
 };
 
 exports.getAppLocation = ({ customLocation }) => {
@@ -99,29 +93,19 @@ exports.getAppLocation = ({ customLocation }) => {
     }
   }
 
-  switch (osType) {
-    case 'Linux':
-      return getLinuxAppDir();
-    case 'Windows_NT':
-      return getWindowsAppDir();
-    case 'Darwin':
-      return getMacAppDir();
-    default:
-      throw 'Unsupported operating system';
-  }
+  if (getIsWindows()) return getWindowsAppDir();
+  if (getIsMac()) return getMacAppDir();
+  if (getIsLinux()) return getLinuxAppDir();
+
+  throw Error('Unsupported operating system');
 };
 
 exports.getResourcesDir = () => {
-  switch (osType) {
-    case 'Linux':
-      return `/resources/`;
-    case 'Windows_NT':
-      return `\\resources\\`;
-    case 'Darwin':
-      return `/Contents/Resources/`;
-    default:
-      throw 'Unsupported operating system';
-  }
+  if (getIsWindows()) return `\\resources\\`;
+  if (getIsMac()) return `/Contents/Resources/`;
+  if (getIsLinux()) return `/resources/`;
+
+  throw Error('Unsupported operating system');
 };
 
 exports.findArchive = (resourcesDir) => {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -10,15 +10,16 @@ exports.windowsCopy = (data) => {
 };
 
 exports.copyToClipboard = (data) => {
-  const osType = os.type();
-  switch (osType) {
-    case 'Linux':
-      return this.pbcopy(data);
-    case 'Windows_NT':
-      return this.windowsCopy(data);
-    case 'Darwin':
-      return this.pbcopy(data);
-    default:
-      throw 'Unsupported operating system';
-  }
+  if (getIsWindows()) return this.windowsCopy(data);
+  if (getIsMac()) return this.pbcopy(data);
+  if (getIsLinux()) return this.pbcopy(data);
+
+  throw Error('Unsupported operating system');
 };
+
+const getIsWindows = () => os.type() === 'Windows_NT';
+const getIsMac = () => os.type() === 'Darwin';
+const getIsLinux = () => os.type() === 'Linux';
+exports.getIsWindows = getIsWindows;
+exports.getIsMac = getIsMac;
+exports.getIsLinux = getIsLinux;

--- a/main.js
+++ b/main.js
@@ -4,6 +4,7 @@ const clear = require('clear');
 const figlet = require('figlet');
 const sample = require('@feizheng/next-sample');
 const cli = require('./lib/cli');
+const { getIsMac } = require('./lib/utils');
 const { execute } = require('./lib/command');
 const pkg = require('./package.json');
 
@@ -21,16 +22,18 @@ async function run() {
   );
   console.log(chalk.italic(`version ${pkg.version} by @mallowigi`));
 
-  console.log(chalk.bold.red(`IMPORTANT UPDATE!!!!!`));
-  console.log('');
-  console.log(
-    `Since version 4.22.0 of Slack, it is no longer possible to apply custom tweaks, as they have patched the option to do so.`
-  );
-  console.log(
-    'However, you can still generate the custom code, that you can paste in Slack dev tools while in dev mode (see README).'
-  );
-  console.log('');
-  console.log('');
+  if (getIsMac()) {
+    console.log(chalk.bold.red(`IMPORTANT UPDATE!!!!!`));
+    console.log('');
+    console.log(
+      `Since version 4.22.0 of Slack, it is no longer possible to apply custom tweaks, as they have patched the option to do so.`
+    );
+    console.log(
+      'However, you can still generate the custom code, that you can paste in Slack dev tools while in dev mode (see README).'
+    );
+    console.log('');
+    console.log('');
+  }
   console.log(chalk.cyan('Welcome to the mtslack CLI!'));
   console.log('');
 


### PR DESCRIPTION
Re-enables the automatically applying of styles for Windows and Mac where #106 does not appear to take effect. 

P.S. I've had an issue with both the official and custom `asar` package where non-existent unpacked files cause a `ENOENT: No such file or directory` error.
![image](https://user-images.githubusercontent.com/10467983/157346524-07b6351a-b9ff-4794-a8b7-b94c939b647f.png)

I fixed the issue by replacing the following line with the code block below

https://github.com/mallowigi/asar/blob/229932f270ca102554491b2ce0c1c7802293ad0b/lib/disk.js#L110

```ts
// it's an unpacked file, attempt to copy it.
const unpackedLocation = path.join(`${filesystem.src}.unpacked`, filename)
if (fs.existsSync(unpackedLocation)) {
  buffer = fs.readFileSync(unpackedLocation)
}
```

Not sure if this is just an issue with my environment or an issue for others as well but this PR doesn't include this patch