### PR TITLE
Change stale bot interval to 14/14

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,13 +1,13 @@
 # Configuration for probot-stale - https://github.com/probot/stale
 
 # Number of days of inactivity before an Issue or Pull Request becomes stale
-daysUntilStale: 1
+daysUntilStale: 14
 
 # Number of days of inactivity before an Issue or Pull Request with the stale
 # label is closed.
 # Set to false to disable. If disabled, issues still need to be closed manually,
 # but will remain marked as stale.
-daysUntilClose: 1
+daysUntilClose: 14
 
 # Issues or Pull Requests with these labels will never be considered stale.
 # Set to `[]` to disable


### PR DESCRIPTION
The stale bot seems to be a bit aggressive with marking PRs as stale. This changes it to be 14 days until stale and 14 days after that until close. Would be nice if it only did this for draft PRs but I couldn't find an option in their docs :disappointed:. PRs that are ready for merging should likely be merged or closed manually since that's up to the maintainers and not the PR author.